### PR TITLE
Worked on better stack trace parsing

### DIFF
--- a/lib/api_maker/spec_helper.rb
+++ b/lib/api_maker/spec_helper.rb
@@ -50,7 +50,7 @@ module ApiMaker::SpecHelper
     return if logs.blank? || !logs.include?("SEVERE ")
 
     # Lets try one more time - just in case browser window error got registered meanwhile
-    sleep 0.2
+    sleep 0.4
     expect_no_browser_window_errors
 
     raise logs

--- a/spec/dummy/app/javascript/api-maker/bootstrap/string-input.jsx
+++ b/spec/dummy/app/javascript/api-maker/bootstrap/string-input.jsx
@@ -78,6 +78,7 @@ export default class BootstrapStringInput extends React.Component {
             className={this.inputClassName()}
             data-controller={this.props["data-controller"]}
             defaultValue={this.inputDefaultValue()}
+            disabled={this.props.disabled}
             id={this.inputId()}
             maxLength={this.props.maxLength}
             name={this.inputName()}


### PR DESCRIPTION
Load all source maps when an error occurs (React lazy adds new chunk scripts along the way)
Parse stack trace for errors which is given by Chrome and Safari
Better code in general