### PR TITLE
Add spec for create command

### DIFF
--- a/spec/api_maker/create_command_spec.rb
+++ b/spec/api_maker/create_command_spec.rb
@@ -25,33 +25,37 @@ describe ApiMaker::CreateCommand do
     command = helper.add_command(args: {save: {task: task_params}})
     helper.execute!
 
-    expect(command.result).to eq(
-      errors: ["Project must exist"],
-      model: {
-        data: {"tasks" => ["new-0"]},
-        preloaded: {
+    json_result = command.result.to_json
+
+    expect(JSON.parse(json_result)).to eq(
+      "errors" => ["Project must exist"],
+      "model" => {
+        "data" => {"tasks" => ["new-0"]},
+        "preloaded" => {
           "tasks" => {
             "new-0" => {
-              "created_at" => nil,
-              "custom_id" => nil,
-              "finished" => nil,
-              "id" => nil,
-              "name" => "Test task",
-              "project_id" => nil,
-              "user_id" => user.id
+              "a" => {
+                "created_at" => nil,
+                "custom_id" => "custom-",
+                "finished" => false,
+                "id" => nil,
+                "name" => "Test task",
+                "project_id" => nil,
+                "user_id" => user.id
+              }
             }
           }
         }
       },
-      success: false,
-      validation_errors: [
+      "success" => false,
+      "validation_errors" => [
         {
-          attribute_name: :project,
-          error_message: "must exist",
-          error_type: :blank,
-          id: nil,
-          input_name: "task[project]",
-          model_name: "task"
+          "attribute_name" => "project",
+          "error_message" => "must exist",
+          "error_type" => "blank",
+          "id" => nil,
+          "input_name" => "task[project]",
+          "model_name" => "task"
         }
       ]
     )

--- a/spec/api_maker/create_command_spec.rb
+++ b/spec/api_maker/create_command_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+describe ApiMaker::CreateCommand do
+  let(:project) { create :project }
+  let(:user) { create :user }
+
+  let(:ability) { ApiMaker::Ability.new(args: {current_user: user}) }
+  let(:api_maker_args) { {current_user: user} }
+  let(:collection) { Task.accessible_by(ability) }
+  let(:controller) { instance_double("ApplicationController", api_maker_args: api_maker_args, current_ability: ability, current_user: user) }
+  let(:helper) do
+    ApiMaker::CommandSpecHelper.new(
+      collection: collection,
+      command: ApiMaker::CreateCommand,
+      controller: controller
+    )
+  end
+
+  it "returns validation errors" do
+    task_params = {
+      name: "Test task",
+      user_id: user.id
+    }
+
+    command = helper.add_command(args: {save: {task: task_params}})
+    helper.execute!
+
+    expect(command.result).to eq(
+      errors: ["Project must exist"],
+      model: {
+        data: {"tasks" => ["new-0"]},
+        preloaded: {
+          "tasks" => {
+            "new-0" => {
+              "created_at" => nil,
+              "custom_id" => nil,
+              "finished" => nil,
+              "id" => nil,
+              "name" => "Test task",
+              "project_id" => nil,
+              "user_id" => user.id
+            }
+          }
+        }
+      },
+      success: false,
+      validation_errors: [
+        {
+          attribute_name: :project,
+          error_message: "must exist",
+          error_type: :blank,
+          id: nil,
+          input_name: "task[project]",
+          model_name: "task"
+        }
+      ]
+    )
+  end
+end

--- a/spec/dummy/app/api_maker/resources/task_resource.rb
+++ b/spec/dummy/app/api_maker/resources/task_resource.rb
@@ -25,6 +25,6 @@ class Resources::TaskResource < Resources::ApplicationResource
   end
 
   def permitted_params(arg)
-    arg.params.require(:task).permit(:finished, :name, :task)
+    arg.params.require(:task).permit(:finished, :name, :project_id, :task, :user_id)
   end
 end


### PR DESCRIPTION
~~Spec is failing because `preloaded` returns ApiMaker::Serializer(`<ApiMaker::Serializer id="" model="Task" relationships="{}">`)  instead of json on failing request~~