### PR TITLE
Use Chrome::Driver#logs

### DIFF
--- a/ruby-gem/lib/api_maker/spec_helper.rb
+++ b/ruby-gem/lib/api_maker/spec_helper.rb
@@ -23,7 +23,7 @@ module ApiMaker::SpecHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def chrome_logs
-    page.driver.browser.manage.logs.get(:browser)
+    page.driver.browser.logs.get(:browser)
   end
 
   def confirm_accept


### PR DESCRIPTION
WARN Selenium [DEPRECATION] Manager#logs is deprecated. Use Chrome::Driver#logs instead.