### PR TITLE
Wrap WebSocket channel DB operations in with_connection

### DIFF
--- a/ruby-gem/app/channels/api_maker/requests_channel.rb
+++ b/ruby-gem/app/channels/api_maker/requests_channel.rb
@@ -78,9 +78,7 @@ private
       @execute_mutex.synchronize do
         ActiveRecord::Base.connection_pool.with_connection { run_command_executor(data, fingerprint:, request_uid:) }
       end
-    when :multi_connection
-      ActiveRecord::Base.connection_pool.with_connection { run_command_executor(data, fingerprint:, request_uid:) }
-    when :none
+    when :multi_connection, :none
       ActiveRecord::Base.connection_pool.with_connection { run_command_executor(data, fingerprint:, request_uid:) }
     end
   end

--- a/ruby-gem/app/channels/api_maker/requests_channel.rb
+++ b/ruby-gem/app/channels/api_maker/requests_channel.rb
@@ -75,11 +75,13 @@ private
   def execute_command(data, fingerprint:, request_uid:)
     case resolved_concurrency_mode
     when :mutex
-      @execute_mutex.synchronize { run_command_executor(data, fingerprint:, request_uid:) }
+      @execute_mutex.synchronize do
+        ActiveRecord::Base.connection_pool.with_connection { run_command_executor(data, fingerprint:, request_uid:) }
+      end
     when :multi_connection
       ActiveRecord::Base.connection_pool.with_connection { run_command_executor(data, fingerprint:, request_uid:) }
     when :none
-      run_command_executor(data, fingerprint:, request_uid:)
+      ActiveRecord::Base.connection_pool.with_connection { run_command_executor(data, fingerprint:, request_uid:) }
     end
   end
 

--- a/ruby-gem/app/channels/api_maker/subscriptions_channel.rb
+++ b/ruby-gem/app/channels/api_maker/subscriptions_channel.rb
@@ -6,14 +6,16 @@ class ApiMaker::SubscriptionsChannel < ApplicationCable::Channel
   def refresh_auth(data)
     request_context = subscription_request_context(data)
 
-    request_context.with_request_context do
-      Services::Devise::PersistSession.execute!(
-        args: data.to_h.deep_symbolize_keys,
-        controller: request_context
-      )
+    ActiveRecord::Base.connection_pool.with_connection do
+      request_context.with_request_context do
+        Services::Devise::PersistSession.execute!(
+          args: data.to_h.deep_symbolize_keys,
+          controller: request_context
+        )
 
-      stop_all_streams
-      resubscribe_to_events!
+        stop_all_streams
+        resubscribe_to_events!
+      end
     end
 
     transmit({type: "api_maker_subscription_auth_refreshed"})
@@ -37,12 +39,14 @@ private
   end
 
   def resubscribe_to_events!
-    if respond_to?(:around_api_maker_subscribe_to_events)
-      around_api_maker_subscribe_to_events do
+    ActiveRecord::Base.connection_pool.with_connection do
+      if respond_to?(:around_api_maker_subscribe_to_events)
+        around_api_maker_subscribe_to_events do
+          subscribe_to_events!
+        end
+      else
         subscribe_to_events!
       end
-    else
-      subscribe_to_events!
     end
   end
 
@@ -83,23 +87,25 @@ private
 
     channel_name = model_class.api_maker_broadcast_create_channel_name
     stream_from(channel_name, coder: ActiveSupport::JSON) do |data|
-      ApiMaker::Configuration.current.before_create_event_callbacks.each do |callback|
-        callback.call(data:)
-      end
+      ActiveRecord::Base.connection_pool.with_connection do
+        ApiMaker::Configuration.current.before_create_event_callbacks.each do |callback|
+          callback.call(data:)
+        end
 
-      # We need to look the model up to evaluate if the user has access
-      model_class = data.fetch("mcn").safe_constantize
+        # We need to look the model up to evaluate if the user has access
+        model_class = data.fetch("mcn").safe_constantize
 
-      Rails.logger.debug { "API maker: ConnectCreates for #{model_class.name}" }
-      model_exists = model_class
-        .accessible_by(current_ability, ability_name)
-        .exists?(model_class.primary_key => data.fetch("mi"))
+        Rails.logger.debug { "API maker: ConnectCreates for #{model_class.name}" }
+        model_exists = model_class
+          .accessible_by(current_ability, ability_name)
+          .exists?(model_class.primary_key => data.fetch("mi"))
 
-      # Transmit the data to JS if its found (and thereby allowed)
-      if model_exists
-        transmit data
-      else
-        Rails.logger.warn { "API maker: No access to connect to #{model_class.name} #{ability_name}" }
+        # Transmit the data to JS if its found (and thereby allowed)
+        if model_exists
+          transmit data
+        else
+          Rails.logger.warn { "API maker: No access to connect to #{model_class.name} #{ability_name}" }
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Wraps all DB-touching operations in `RequestsChannel` and `SubscriptionsChannel` in `ActiveRecord::Base.connection_pool.with_connection` blocks
- Prevents long-lived WebSocket connections from holding onto database connections and exhausting the pool
- The `:mutex` and `:none` concurrency modes in `RequestsChannel` were missing `with_connection` wrapping (only `:multi_connection` had it)
- `SubscriptionsChannel` had no connection management at all — subscription setup queries, `connect_creates` stream callbacks, and `refresh_auth` all ran without wrapping

## Changes
- **`RequestsChannel#execute_command`**: Added `with_connection` inside `:mutex` and `:none` modes
- **`SubscriptionsChannel#resubscribe_to_events!`**: Wrapped in `with_connection` to cover all subscription setup DB queries (`.accessible_by(...).ids`, `.exists?`, etc.)
- **`SubscriptionsChannel#connect_creates`**: Wrapped the `stream_from` callback in `with_connection` since it runs `.exists?` on every broadcast event
- **`SubscriptionsChannel#refresh_auth`**: Wrapped DB work in `with_connection`

## Notes
- `with_connection` is reentrant — nested calls reuse the existing checkout, so this is safe even when called from within other `with_connection` blocks
- Connections are returned to the pool as soon as each block exits, keeping idle WebSocket connections from pinning DB connections

## Test plan
- [ ] Verify WebSocket request execution still works (commands, creates, updates, destroys, events)
- [ ] Verify subscription auth refresh works
- [ ] Monitor DB connection pool usage under load to confirm connections are released between requests


🤖 Generated with [Claude Code](https://claude.com/claude-code)