### PR TITLE
Refresh stale sessions after websocket no-access errors

### DIFF
--- a/changelog.d/20260416-stale-websocket-no-access-session-refresh.md
+++ b/changelog.d/20260416-stale-websocket-no-access-session-refresh.md
@@ -1,0 +1,1 @@
+"ApiMaker now classifies websocket member-command no-access failures with a dedicated `not_found_or_no_access` error type and refreshes frontend session status when those failures happen against a stale signed-in client."

--- a/npm-api-maker/__tests__/commands-pool.test.js
+++ b/npm-api-maker/__tests__/commands-pool.test.js
@@ -1,5 +1,7 @@
 import ApiMakerCommandsPool from "../src/commands-pool.js"
 import Config from "../src/config.js"
+import Devise from "../src/devise.js"
+import SessionStatusUpdater from "../src/session-status-updater.js"
 import WebsocketRequestClient from "../src/websocket-request-client.js"
 import {jest} from "@jest/globals"
 
@@ -37,5 +39,27 @@ describe("ApiMakerCommandsPool", () => {
       request: {pool: {}}
     })
     expect(response).toEqual({via: "websocket"})
+  })
+
+  it("refreshes session status when a failed command reports not_found_or_no_access while signed in", async() => {
+    const pool = new ApiMakerCommandsPool()
+    const commandExecution = {
+      reject: jest.fn(),
+      resolve: jest.fn()
+    }
+    const refreshSessionStatus = jest.spyOn(SessionStatusUpdater.current(), "updateSessionStatus").mockResolvedValue(undefined)
+
+    Devise.current().currents.user = {id: () => "user-1"}
+
+    await pool.handleFailedResponse(
+      {commandExecution},
+      {
+        error_type: "not_found_or_no_access",
+        errors: [{message: "no access", type: "not_found_or_no_access"}]
+      }
+    )
+
+    expect(refreshSessionStatus).toHaveBeenCalledTimes(1)
+    expect(commandExecution.reject).toHaveBeenCalledTimes(1)
   })
 })

--- a/npm-api-maker/__tests__/commands-pool.test.js
+++ b/npm-api-maker/__tests__/commands-pool.test.js
@@ -8,6 +8,8 @@ import {jest} from "@jest/globals"
 describe("ApiMakerCommandsPool", () => {
   afterEach(() => {
     jest.restoreAllMocks()
+    delete globalThis.apiMakerDeviseCurrent
+    globalThis.ApiMakerDevise = {scopes: {}}
   })
 
   it("uses websocket requests whenever they are enabled and no files are present", async() => {
@@ -49,7 +51,8 @@ describe("ApiMakerCommandsPool", () => {
     }
     const refreshSessionStatus = jest.spyOn(SessionStatusUpdater.current(), "updateSessionStatus").mockResolvedValue(undefined)
 
-    Devise.current().currents.user = {id: () => "user-1"}
+    Devise.addUserScope("user")
+    globalThis.apiMakerDeviseCurrent = {user: {id: "user-1"}}
 
     await pool.handleFailedResponse(
       {commandExecution},
@@ -60,6 +63,28 @@ describe("ApiMakerCommandsPool", () => {
     )
 
     expect(refreshSessionStatus).toHaveBeenCalledTimes(1)
+    expect(commandExecution.reject).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not refresh session status when no registered scope is signed in", async() => {
+    const pool = new ApiMakerCommandsPool()
+    const commandExecution = {
+      reject: jest.fn(),
+      resolve: jest.fn()
+    }
+    const refreshSessionStatus = jest.spyOn(SessionStatusUpdater.current(), "updateSessionStatus").mockResolvedValue(undefined)
+
+    Devise.addUserScope("user")
+
+    await pool.handleFailedResponse(
+      {commandExecution},
+      {
+        error_type: "not_found_or_no_access",
+        errors: [{message: "no access", type: "not_found_or_no_access"}]
+      }
+    )
+
+    expect(refreshSessionStatus).not.toHaveBeenCalled()
     expect(commandExecution.reject).toHaveBeenCalledTimes(1)
   })
 })

--- a/npm-api-maker/src/commands-pool.js
+++ b/npm-api-maker/src/commands-pool.js
@@ -7,6 +7,7 @@ import Config from "./config.js"
 import CustomError from "./custom-error.js"
 import DestroyError from "./destroy-error.js"
 import Deserializer from "./deserializer.js" // eslint-disable-line sort-imports
+import Devise from "./devise.js"
 import {dig, digg} from "diggerize" // eslint-disable-line sort-imports
 import events from "./events.js"
 import FormDataObjectizer from "form-data-objectizer" // eslint-disable-line sort-imports
@@ -190,7 +191,7 @@ export default class ApiMakerCommandsPool {
       const commandExecution = Object.values(currentPool)[0]?.commandExecution
       const response = await this.sendRequest({commandExecution, commandSubmitData, url})
 
-      for (const commandId in response.responses) {
+      await Promise.all(Object.keys(response.responses).map(async(commandId) => {
         const commandResponse = response.responses[commandId]
         const commandResponseData = Deserializer.parse(commandResponse.data)
         const commandData = currentPool[parseInt(commandId, 10)]
@@ -216,11 +217,11 @@ export default class ApiMakerCommandsPool {
 
           commandData.commandExecution.reject(error)
         } else if (responseType == "failed") {
-          this.handleFailedResponse(commandData, commandResponseData)
+          await this.handleFailedResponse(commandData, commandResponseData)
         } else {
           throw new Error(`Unhandled response type: ${responseType}`)
         }
-      }
+      }))
     } finally {
       this.flushCount--
     }
@@ -232,9 +233,11 @@ export default class ApiMakerCommandsPool {
    * @param {string} commandResponseData.error_type
    * @param {string[]} commandResponseData.errors
    * @param {string[]} commandResponseData.validation_errors
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  handleFailedResponse(commandData, commandResponseData) {
+  async handleFailedResponse(commandData, commandResponseData) {
+    await this.refreshSessionStatusForNoAccessError(commandResponseData)
+
     let error
 
     if (commandResponseData.error_type == "destroy_error") {
@@ -258,6 +261,22 @@ export default class ApiMakerCommandsPool {
     }
 
     commandData.commandExecution.reject(error)
+  }
+
+  /**
+   * @param {Record<string, any>} commandResponseData
+   * @returns {Promise<void>}
+   */
+  async refreshSessionStatusForNoAccessError(commandResponseData) {
+    if (commandResponseData.error_type != "not_found_or_no_access") {
+      return
+    }
+
+    if (!Object.values(Devise.current().currents).some(Boolean)) {
+      return
+    }
+
+    await SessionStatusUpdater.current().updateSessionStatus()
   }
 
   /** isActive. */

--- a/npm-api-maker/src/commands-pool.js
+++ b/npm-api-maker/src/commands-pool.js
@@ -272,7 +272,11 @@ export default class ApiMakerCommandsPool {
       return
     }
 
-    if (!Object.values(Devise.current().currents).some(Boolean)) {
+    const signedInScope = Devise
+      .registeredScopes()
+      .find((scope) => Devise.current().hasCurrentScope(scope) || Devise.current().hasGlobalCurrentScope(scope))
+
+    if (!signedInScope) {
       return
     }
 

--- a/npm-api-maker/src/devise.js
+++ b/npm-api-maker/src/devise.js
@@ -54,6 +54,7 @@ export default class ApiMakerDevise {
     const getScopeName = `get${scopeCamelized}Scope`
     const scopeInstance = new DeviseScope(scope, args)
 
+    shared.scopes[scope] = true
     ApiMakerDevise[currentMethodName] = () => ApiMakerDevise.current().getCurrentScope(scope)
     ApiMakerDevise[isSignedInMethodName] = () => Boolean(ApiMakerDevise.current().getCurrentScope(scope))
     ApiMakerDevise[getArgsMethodName] = () => args
@@ -66,6 +67,11 @@ export default class ApiMakerDevise {
     const getScopeName = `get${scopeCamelized}Scope`
 
     return ApiMakerDevise[getScopeName]()
+  }
+
+  /** @returns {string[]} */
+  static registeredScopes() {
+    return Object.keys(shared.scopes)
   }
 
   static async signIn(username, password, args = {}) {

--- a/ruby-gem/app/services/api_maker/base_command.rb
+++ b/ruby-gem/app/services/api_maker/base_command.rb
@@ -38,6 +38,14 @@ class ApiMaker::BaseCommand
     end
   end
 
+  def self.command_error_type(error)
+    if error.is_a?(ApiMaker::IndividualCommand::NotFoundOrNoAccessError)
+      :not_found_or_no_access
+    else
+      :runtime_error
+    end
+  end
+
   def self.execute_in_thread!(ability:, api_maker_args:, collection:, commands:, command_response:, controller:)
     command_response.with_thread do
       if const_defined?(:CollectionInstance)
@@ -130,9 +138,11 @@ class ApiMaker::BaseCommand
         yield command
       end
     rescue => e # rubocop:disable Style/RescueStandardError
+      error_type = command_error_type(e)
       error_response = {
+        error_type:,
         success: false,
-        errors: [{message: command_error_message(e), type: :runtime_error}]
+        errors: [{message: command_error_message(e), type: error_type}]
       }
 
       Rails.logger.error e.message

--- a/ruby-gem/spec/services/api_maker/base_command_spec.rb
+++ b/ruby-gem/spec/services/api_maker/base_command_spec.rb
@@ -141,4 +141,10 @@ describe ApiMaker::BaseCommand do
     expect(result.fetch(:test_collection_command_called)).to be true
     expect(result.dig!(:api_maker_args, :passed)).to be true
   end
+
+  it "classifies not_found_or_no_access errors with a dedicated error type" do
+    error = ApiMaker::IndividualCommand::NotFoundOrNoAccessError.new("no access")
+
+    expect(described_class.command_error_type(error)).to eq(:not_found_or_no_access)
+  end
 end


### PR DESCRIPTION
## Problem
Stale signed-in websocket clients can keep issuing member commands after the backend session has expired or been cleared. Those failures came back as generic runtime errors, so the frontend did not refresh auth state and kept showing noisy no-access failures.

## Solution
- classify `ApiMaker::IndividualCommand::NotFoundOrNoAccessError` as `not_found_or_no_access`
- refresh frontend session status when failed websocket commands return that error while a scope still looks signed in locally
- add regression coverage and a changelog fragment

## Testing
- `bundle exec rubocop app/services/api_maker/base_command.rb spec/services/api_maker/base_command_spec.rb`
- `bundle exec rspec spec/services/api_maker/base_command_spec.rb spec/services/api_maker/command_request_executor_spec.rb`
- `npm run lint:eslint -- src/commands-pool.js __tests__/commands-pool.test.js`
- `npm run typecheck:file -- --file=src/commands-pool.js`
- `npm run typecheck:file -- --file=__tests__/commands-pool.test.js`
- `npm test -- --runTestsByPath __tests__/commands-pool.test.js`
