### PR TITLE
Add ActionCable cleanup helpers for system specs

### DIFF
--- a/npm-api-maker/README.md
+++ b/npm-api-maker/README.md
@@ -161,6 +161,26 @@ import resetRealtimeRuntimeState from "@kaspernj/api-maker/build/reset-realtime-
 resetRealtimeRuntimeState()
 ```
 
+### System test ActionCable cleanup (Ruby)
+
+When using `use_transactional_fixtures = true` with system specs, ActionCable disconnect Fibers can hold the shared DB connection after the browser is killed, causing all subsequent tests to fail. Api Maker provides two helpers to prevent this:
+
+**`reset_api_maker_realtime_runtime!`** — calls the auto-registered JS hook to gracefully disconnect ActionCable from the browser side before quitting the session. Returns `:ok`, `:missing`, `:error`, or `:unavailable`.
+
+**`wait_for_action_cable_connections_to_close!`** — waits for server-side ActionCable connections to drain so disconnect Fibers release the shared DB connection.
+
+Wire both into your test cleanup:
+
+```ruby
+# In your rails_helper.rb ensure block, after resetting Capybara sessions
+# and before DatabaseCleaner.clean:
+reset_api_maker_realtime_runtime!
+Capybara.reset!
+wait_for_action_cable_connections_to_close!
+```
+
+The JS hook is auto-registered on `globalThis.__apiMakerResetRealtimeRuntimeForSystemSpecs` when the module is loaded — downstream projects no longer need to register it manually.
+
 ## Realtime model events
 
 For model-specific websocket events in React/ShapeComponent UI code, prefer `useModelEvent` over manual `ModelEvents.connect(...)` subscriptions. The hook handles subscription lifecycle automatically and avoids leaked listeners.

--- a/npm-api-maker/__tests__/reset-realtime-runtime-state.test.js
+++ b/npm-api-maker/__tests__/reset-realtime-runtime-state.test.js
@@ -9,6 +9,11 @@ describe("resetRealtimeRuntimeState", () => {
     delete globalThis.apiMakerChannelsConsumer
   })
 
+  it("auto-registers the reset hook on globalThis for Ruby system-test helpers", () => {
+    // eslint-disable-next-line no-underscore-dangle
+    expect(globalThis.__apiMakerResetRealtimeRuntimeForSystemSpecs).toBe(waitForRealtimeRuntimeIdleAndReset)
+  })
+
   it("waits for websocket requests to go idle before resetting the realtime runtime", async() => {
     const waitForIdle = jest.fn().mockResolvedValue(undefined)
 

--- a/npm-api-maker/src/reset-realtime-runtime-state.js
+++ b/npm-api-maker/src/reset-realtime-runtime-state.js
@@ -21,5 +21,10 @@ const waitForRealtimeRuntimeIdleAndReset = async({timeoutMs = 5000} = {}) => {
   resetRealtimeRuntimeState()
 }
 
+// Auto-register the reset hook so Ruby system-test helpers can call it
+// without downstream projects needing to wire it up manually.
+// eslint-disable-next-line no-underscore-dangle
+globalThis.__apiMakerResetRealtimeRuntimeForSystemSpecs = waitForRealtimeRuntimeIdleAndReset
+
 export {waitForRealtimeRuntimeIdleAndReset}
 export default resetRealtimeRuntimeState

--- a/ruby-gem/lib/api_maker/spec_helper.rb
+++ b/ruby-gem/lib/api_maker/spec_helper.rb
@@ -4,6 +4,7 @@ module ApiMaker::SpecHelper # rubocop:disable Metrics/ModuleLength
   autoload :ExecuteCollectionCommand, "#{__dir__}/spec_helper/execute_collection_command"
   autoload :ExecuteMemberCommand, "#{__dir__}/spec_helper/execute_member_command"
 
+  require_relative "spec_helper/action_cable_cleanup"
   require_relative "spec_helper/attribute_row_helpers"
   require_relative "spec_helper/browser_logs"
   require_relative "spec_helper/expect_no_browser_errors"
@@ -14,6 +15,7 @@ module ApiMaker::SpecHelper # rubocop:disable Metrics/ModuleLength
   require_relative "spec_helper/wait_for_flash_message"
   require_relative "spec_helper/wait_for_selector"
   require_relative "spec_helper/worker_plugins_helpers"
+  include ActionCableCleanup
   include BrowserLogs
   include ApiMaker::ExpectToBeAbleToHelper
   include AttributeRowHelpers

--- a/ruby-gem/lib/api_maker/spec_helper/action_cable_cleanup.rb
+++ b/ruby-gem/lib/api_maker/spec_helper/action_cable_cleanup.rb
@@ -1,0 +1,97 @@
+module ApiMaker::SpecHelper::ActionCableCleanup
+  CAPYBARA_DISCONNECT_ERRORS = [
+    EOFError,
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET
+  ].freeze
+
+  CAPYBARA_DISCONNECT_MESSAGES = [
+    "browser has closed the connection",
+    "chrome not reachable",
+    "disconnected",
+    "failed to open tcp connection",
+    "invalid session id",
+    "session deleted because of page crash",
+    "unable to connect to",
+    "unable to read true browser url"
+  ].freeze
+
+  # Resets the Api Maker realtime runtime (ActionCable consumer, connection pool,
+  # websocket request client) from the browser side by calling the auto-registered
+  # JS hook. Returns a status symbol:
+  #   :ok           — reset ran successfully
+  #   :missing      — hook not on the page (fresh session, about:blank, non-app page)
+  #   :error        — the hook threw; caller should treat the runtime as untrusted
+  #   :unavailable  — no driver yet or disconnected during the call
+  def reset_api_maker_realtime_runtime!
+    session = Capybara.current_session
+    return :unavailable unless api_maker_session_has_driver?(session)
+
+    status = :unavailable
+    api_maker_ignore_capybara_disconnect do
+      result = session.evaluate_async_script(<<~JS, 5)
+        const done = arguments[0]
+        const timeoutMs = arguments[1]
+        const resetHook = globalThis.__apiMakerResetRealtimeRuntimeForSystemSpecs
+
+        if (!resetHook) {
+          done({status: "missing"})
+          return
+        }
+
+        Promise
+          .resolve(resetHook({timeoutMs}))
+          .then(() => done({status: "ok"}))
+          .catch((error) => done({errorClass: error?.constructor?.name, errorMessage: error?.message, status: "error"}))
+      JS
+
+      status = result["status"].to_sym
+      warn "Api Maker realtime reset failed: #{result["errorClass"]}: #{result["errorMessage"]}" if status == :error
+    end
+
+    status
+  rescue Capybara::NotSupportedByDriverError
+    :unavailable
+  end
+
+  # Waits for all server-side ActionCable connections to close. Call this after
+  # quitting/resetting the browser session so that ActionCable disconnect Fibers
+  # finish and release the shared DB connection before the next test starts.
+  #
+  # Without this wait, the disconnect Fibers can still hold the DB connection
+  # when the next test calls DatabaseCleaner.start, causing "This connection is
+  # in use by: #<Fiber:...>" and eventually a force-reconnect that permanently
+  # breaks use_transactional_fixtures for the rest of the test run.
+  def wait_for_action_cable_connections_to_close!(timeout: 5)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+
+    while ActionCable.server.connections.any?
+      break if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep 0.05
+    end
+  end
+
+private
+
+  def api_maker_session_has_driver?(session)
+    session.instance_variable_get(:@driver).present?
+  end
+
+  def api_maker_ignore_capybara_disconnect
+    yield
+  rescue *CAPYBARA_DISCONNECT_ERRORS, Selenium::WebDriver::Error::WebDriverError => e
+    raise unless api_maker_capybara_disconnect_error?(e)
+
+    nil
+  end
+
+  def api_maker_capybara_disconnect_error?(error)
+    return true if CAPYBARA_DISCONNECT_ERRORS.any? { |disconnect_error| error.is_a?(disconnect_error) }
+    return false unless error.is_a?(Selenium::WebDriver::Error::WebDriverError)
+
+    error_message = error.message.to_s.downcase
+
+    CAPYBARA_DISCONNECT_MESSAGES.any? { |disconnect_message| error_message.include?(disconnect_message) }
+  end
+end

--- a/ruby-gem/lib/api_maker/spec_helper/action_cable_cleanup.rb
+++ b/ruby-gem/lib/api_maker/spec_helper/action_cable_cleanup.rb
@@ -29,9 +29,9 @@ module ApiMaker::SpecHelper::ActionCableCleanup
 
     status = :unavailable
     api_maker_ignore_capybara_disconnect do
-      result = session.evaluate_async_script(<<~JS, 5)
-        const done = arguments[0]
-        const timeoutMs = arguments[1]
+      result = session.evaluate_async_script(<<~JS, 5000)
+        const timeoutMs = arguments[0]
+        const done = arguments[arguments.length - 1]
         const resetHook = globalThis.__apiMakerResetRealtimeRuntimeForSystemSpecs
 
         if (!resetHook) {

--- a/ruby-gem/spec/system/action_cable_cleanup_spec.rb
+++ b/ruby-gem/spec/system/action_cable_cleanup_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe "ActionCableCleanup" do
+  describe "#reset_api_maker_realtime_runtime!" do
+    it "returns :missing when the JS hook is not registered" do
+      visit root_path
+
+      status = reset_api_maker_realtime_runtime!
+
+      expect(status).to eq(:missing)
+    end
+  end
+
+  describe "#wait_for_action_cable_connections_to_close!" do
+    it "returns immediately when there are no connections" do
+      expect(ActionCable.server.connections).to be_empty
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      wait_for_action_cable_connections_to_close!(timeout: 1)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+      expect(elapsed).to be < 0.5
+    end
+
+    it "waits until connections drain" do
+      fake_connection = instance_double("ActionCable::Connection::Base")
+      connections = ActionCable.server.connections
+
+      connections << fake_connection
+
+      Thread.new do
+        sleep 0.2
+        connections.delete(fake_connection)
+      end
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      wait_for_action_cable_connections_to_close!(timeout: 5)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+      expect(elapsed).to be >= 0.15
+      expect(connections).to be_empty
+    end
+
+    it "respects the timeout when connections do not drain" do
+      fake_connection = instance_double("ActionCable::Connection::Base")
+      connections = ActionCable.server.connections
+
+      connections << fake_connection
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      wait_for_action_cable_connections_to_close!(timeout: 0.3)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+      expect(elapsed).to be >= 0.25
+      expect(elapsed).to be < 1.0
+    ensure
+      connections.delete(fake_connection)
+    end
+  end
+end

--- a/ruby-gem/spec/system/action_cable_cleanup_spec.rb
+++ b/ruby-gem/spec/system/action_cable_cleanup_spec.rb
@@ -23,7 +23,7 @@ describe "ActionCableCleanup" do
     end
 
     it "waits until connections drain" do
-      fake_connection = instance_double("ActionCable::Connection::Base")
+      fake_connection = instance_double(ActionCable::Connection::Base)
       connections = ActionCable.server.connections
 
       connections << fake_connection
@@ -42,7 +42,7 @@ describe "ActionCableCleanup" do
     end
 
     it "respects the timeout when connections do not drain" do
-      fake_connection = instance_double("ActionCable::Connection::Base")
+      fake_connection = instance_double(ActionCable::Connection::Base)
       connections = ActionCable.server.connections
 
       connections << fake_connection


### PR DESCRIPTION
## Summary

- Auto-register `waitForRealtimeRuntimeIdleAndReset` on `globalThis.__apiMakerResetRealtimeRuntimeForSystemSpecs` so Ruby system-test helpers can call it without downstream projects needing to wire it up manually
- Add `reset_api_maker_realtime_runtime!` Ruby helper that calls the JS hook to gracefully disconnect ActionCable from the browser side
- Add `wait_for_action_cable_connections_to_close!` Ruby helper that waits for server-side ActionCable connections to drain

## Problem

When using `use_transactional_fixtures = true` with system specs, ActionCable disconnect Fibers can hold the shared DB connection after the browser is killed during test cleanup. This causes `wait_for_database_connection_available!` to force-reconnect (`disconnect!` + `establish_connection`), which permanently breaks the transactional fixtures shared connection mechanism for the rest of the test run. Every subsequent test fails because Puma serves pages from a different connection that can't see the test's transaction data.

## Solution

Downstream projects wire the new helpers into their cleanup flow:

```ruby
# In rails_helper.rb ensure block, before DatabaseCleaner.clean:
reset_api_maker_realtime_runtime!
Capybara.reset!
wait_for_action_cable_connections_to_close!
```

This ensures ActionCable Fibers release the shared DB connection before the next test starts.

## Test plan

- [x] JS test verifies auto-registration of the globalThis hook
- [x] Existing JS tests continue to pass
- [ ] Wire into wooftech rails_helper and verify CI cascade no longer occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)