### PR TITLE
Preserve caller stack on all command-pool rejection paths

### DIFF
--- a/npm-api-maker/__tests__/commands-pool.test.js
+++ b/npm-api-maker/__tests__/commands-pool.test.js
@@ -87,4 +87,113 @@ describe("ApiMakerCommandsPool", () => {
     expect(refreshSessionStatus).not.toHaveBeenCalled()
     expect(commandExecution.reject).toHaveBeenCalledTimes(1)
   })
+
+  describe("rejectWithCallerStack", () => {
+    it("appends V8-style caller frames (stripping the 'Error' header) to the rejection error", () => {
+      const pool = new ApiMakerCommandsPool()
+      const commandExecution = {reject: jest.fn()}
+      const error = new Error("boom")
+
+      error.stack = "Error: boom\n    at flush (commands-pool.js:1:1)"
+
+      const callerStack = "Error\n    at callerFrame (some-file.js:1:1)\n    at outerFrame (other-file.js:2:2)"
+
+      pool.rejectWithCallerStack({commandExecution, stack: callerStack}, error)
+
+      expect(commandExecution.reject).toHaveBeenCalledTimes(1)
+      const rejected = commandExecution.reject.mock.calls[0][0]
+
+      expect(rejected).toBe(error)
+      expect(rejected.stack).toContain("at flush (commands-pool.js:1:1)")
+      expect(rejected.stack).toContain("at callerFrame (some-file.js:1:1)")
+      expect(rejected.stack).toContain("at outerFrame (other-file.js:2:2)")
+    })
+
+    it("keeps non-V8 caller frames intact (no 'Error' header to strip)", () => {
+      const pool = new ApiMakerCommandsPool()
+      const commandExecution = {reject: jest.fn()}
+      const error = new Error("boom")
+
+      error.stack = "flushInternal@commands-pool.js:1:1"
+
+      const callerStack = "callerFrame@some-file.js:10:5\nouterFrame@other-file.js:2:2"
+
+      pool.rejectWithCallerStack({commandExecution, stack: callerStack}, error)
+
+      const rejected = commandExecution.reject.mock.calls[0][0]
+
+      expect(rejected.stack).toContain("flushInternal@commands-pool.js:1:1")
+      expect(rejected.stack).toContain("callerFrame@some-file.js:10:5")
+      expect(rejected.stack).toContain("outerFrame@other-file.js:2:2")
+    })
+
+    it("rejects without touching the stack when no caller stack was captured", () => {
+      const pool = new ApiMakerCommandsPool()
+      const commandExecution = {reject: jest.fn()}
+      const error = new Error("boom")
+      const originalStack = error.stack
+
+      pool.rejectWithCallerStack({commandExecution}, error)
+
+      expect(commandExecution.reject).toHaveBeenCalledWith(error)
+      expect(error.stack).toEqual(originalStack)
+    })
+  })
+
+  describe("handleFailedResponse stack preservation", () => {
+    const callerStack = "Error\n    at someCaller (app.js:42:13)"
+
+    it("preserves caller stack on generic command failure", async() => {
+      const pool = new ApiMakerCommandsPool()
+      const commandExecution = {reject: jest.fn(), resolve: jest.fn()}
+
+      await pool.handleFailedResponse(
+        {commandExecution, stack: callerStack},
+        {
+          error_type: "custom_error",
+          errors: [{message: "limit reached"}]
+        }
+      )
+
+      expect(commandExecution.reject).toHaveBeenCalledTimes(1)
+      const rejected = commandExecution.reject.mock.calls[0][0]
+
+      expect(rejected.stack).toContain("at someCaller (app.js:42:13)")
+    })
+
+    it("preserves caller stack on destroy_error", async() => {
+      const pool = new ApiMakerCommandsPool()
+      const commandExecution = {reject: jest.fn(), resolve: jest.fn()}
+
+      await pool.handleFailedResponse(
+        {commandExecution, stack: callerStack},
+        {
+          error_type: "destroy_error",
+          errors: [{message: "cannot destroy"}]
+        }
+      )
+
+      const rejected = commandExecution.reject.mock.calls[0][0]
+
+      expect(rejected.stack).toContain("at someCaller (app.js:42:13)")
+    })
+
+    it("preserves caller stack on validation_error", async() => {
+      const pool = new ApiMakerCommandsPool()
+      const commandExecution = {reject: jest.fn(), resolve: jest.fn()}
+
+      await pool.handleFailedResponse(
+        {commandExecution, stack: callerStack},
+        {
+          error_type: "validation_error",
+          model: {id: "1"},
+          validation_errors: []
+        }
+      )
+
+      const rejected = commandExecution.reject.mock.calls[0][0]
+
+      expect(rejected.stack).toContain("at someCaller (app.js:42:13)")
+    })
+  })
 })

--- a/npm-api-maker/changelog.d/20260417-commands-pool-caller-stack.md
+++ b/npm-api-maker/changelog.d/20260417-commands-pool-caller-stack.md
@@ -1,0 +1,1 @@
+Fixed `ApiMakerCommandsPool` losing the caller's stack trace on `failed`, `destroy_error`, and `validation_error` responses. The caller stack captured synchronously in `addCommand()` is now spliced onto the rejection error through a shared `rejectWithCallerStack` helper (applied to every reject site), and the splice handles both V8- and JSC/SpiderMonkey-shaped stack strings.

--- a/npm-api-maker/src/commands-pool.js
+++ b/npm-api-maker/src/commands-pool.js
@@ -208,14 +208,7 @@ export default class ApiMakerCommandsPool {
         if (responseType == "success") {
           commandData.commandExecution.resolve(commandResponseData)
         } else if (responseType == "error") {
-          const error = new CustomError("Command error", {response: commandResponseData})
-
-          error.stack += "\n"
-          error.stack += commandData.stack.split("\n")
-            .slice(1)
-            .join("\n")
-
-          commandData.commandExecution.reject(error)
+          this.rejectWithCallerStack(commandData, new CustomError("Command error", {response: commandResponseData}))
         } else if (responseType == "failed") {
           await this.handleFailedResponse(commandData, commandResponseData)
         } else {
@@ -251,13 +244,34 @@ export default class ApiMakerCommandsPool {
 
       events.emit("onValidationErrors", validationErrors)
     } else {
-      let errorMessage
-
-      if (!commandResponseData.errors) {
-        errorMessage = "Command failed"
-      }
+      const errorMessage = commandResponseData.errors ? undefined : "Command failed"
 
       error = new CustomError(errorMessage, {response: commandResponseData})
+    }
+
+    this.rejectWithCallerStack(commandData, error)
+  }
+
+  /**
+   * Rejects the command with the given error, splicing the caller's stack (captured synchronously in addCommand) onto error.stack.
+   * Needed because error.stack is frozen at construction time inside flush()'s microtask and therefore loses the caller's frames.
+   * @param {CommandDataType} commandData
+   * @param {Error} error
+   * @returns {void}
+   */
+  rejectWithCallerStack(commandData, error) {
+    if (commandData.stack) {
+      // V8 prefixes "Error\n" as a header; JSC/SpiderMonkey stacks start directly with a frame.
+      const callerFrames = commandData.stack.startsWith("Error")
+        ? commandData.stack
+          .split("\n")
+          .slice(1)
+          .join("\n")
+        : commandData.stack
+
+      if (callerFrames) {
+        error.stack = `${error.stack ?? ""}\n${callerFrames}`
+      }
     }
 
     commandData.commandExecution.reject(error)


### PR DESCRIPTION
## Summary
- `ApiMakerCommandsPool` captures the caller's stack synchronously in `addCommand()` and spliced it onto the rejected error inside `flush()`'s `"error"` branch — but the sibling `"failed"` path (`destroy_error`, `validation_error`, and generic custom errors) never reattached it. Bug reports from those branches only showed Promise/microtask frames inside `flush()` (e.g. `at <unknown> (commands-pool.js:260:30)` with no caller frame).
- Extracted a `rejectWithCallerStack` helper and called it from every reject site so new response types cannot regress.
- Splicing now supports both V8 (`Error\n  at …`) and JSC/SpiderMonkey stack shapes, so Safari bug reports keep a real caller frame instead of dropping it.

## Why this approach (and not `Error#cause`)
This is one logical error. The caller stack is lost purely because of Promise mechanics: `new CustomError(...)` is constructed on a microtask tick inside `flush()`, where the live call stack is just the Promise plumbing. Most browsers only expose async frames in DevTools, not on the serialized `error.stack` that remote bug reporters capture. So we capture the caller's sync stack at `addCommand()` (where its frames are still alive) and splice it onto the final error's `.stack` — rather than wrapping it as a separate `cause`, which would imply two distinct errors.

## Test plan
- [x] `npm run lint:eslint -- src/commands-pool.js __tests__/commands-pool.test.js`
- [x] `FILE=src/commands-pool.js npm run typecheck:file`
- [x] `NODE_OPTIONS=--experimental-vm-modules npx jest __tests__/commands-pool.test.js` — 9 tests pass, including:
  - `rejectWithCallerStack` appends V8-style caller frames (stripping the `Error` header)
  - `rejectWithCallerStack` keeps non-V8 caller frames intact
  - `rejectWithCallerStack` no-ops when no caller stack was captured
  - `handleFailedResponse` preserves caller stack on generic / `destroy_error` / `validation_error` responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)