### PR TITLE
Set current_user in api_maker_args for ActionCable requests

### DIFF
--- a/ruby-gem/app/services/api_maker/action_cable_request_context.rb
+++ b/ruby-gem/app/services/api_maker/action_cable_request_context.rb
@@ -7,9 +7,9 @@ class ApiMaker::ActionCableRequestContext
     @channel = channel
     @api_maker_args = api_maker_args.merge(
       controller: self,
-      current_session_id: api_maker_args[:current_session_id].presence || channel.current_session_id,
-      current_user: channel.current_user
+      current_session_id: api_maker_args[:current_session_id].presence || channel.current_session_id
     )
+    set_current_devise_scope_models!
     @api_maker_locals = channel.api_maker_locals
     @request_fingerprint = request_fingerprint
     @request_uid = request_uid
@@ -124,6 +124,24 @@ class ApiMaker::ActionCableRequestContext
   end
 
 private
+
+  # Set current_#{param_key} in api_maker_args for every registered Devise
+  # scope so resource abilities can read them the same way they do on HTTP
+  # requests (where Devise controller helpers define the methods).
+  def set_current_devise_scope_models!
+    warden_proxy = channel.connection.env["warden"]
+    return unless warden_proxy
+
+    Devise.mappings.each_value do |mapping|
+      model_class = mapping.class_name.safe_constantize
+      next unless model_class
+
+      param_key = model_class.model_name.param_key
+      key = :"current_#{param_key}"
+
+      @api_maker_args[key] ||= warden_proxy.user(mapping.name)
+    end
+  end
 
   def warden
     channel.connection.env.fetch("warden")

--- a/ruby-gem/app/services/api_maker/action_cable_request_context.rb
+++ b/ruby-gem/app/services/api_maker/action_cable_request_context.rb
@@ -7,7 +7,8 @@ class ApiMaker::ActionCableRequestContext
     @channel = channel
     @api_maker_args = api_maker_args.merge(
       controller: self,
-      current_session_id: api_maker_args[:current_session_id].presence || channel.current_session_id
+      current_session_id: api_maker_args[:current_session_id].presence || channel.current_session_id,
+      current_user: channel.current_user
     )
     @api_maker_locals = channel.api_maker_locals
     @request_fingerprint = request_fingerprint

--- a/ruby-gem/spec/services/api_maker/action_cable_request_context_spec.rb
+++ b/ruby-gem/spec/services/api_maker/action_cable_request_context_spec.rb
@@ -25,6 +25,8 @@ describe ApiMaker::ActionCableRequestContext do
     end
   end
   let(:request_context) do
+    allow(warden).to receive(:user).with(:user).and_return(nil)
+
     described_class.new(
       api_maker_args: {current_user: nil},
       channel:,
@@ -88,10 +90,17 @@ describe ApiMaker::ActionCableRequestContext do
   end
 
   it "returns session status for the current websocket state" do
-    expect(warden).to receive(:user).with(:user).and_return(user)
+    allow(warden).to receive(:user).with(:user).and_return(user)
     expect(warden).to receive(:authenticated?).with(:user).and_return(true)
 
-    result = request_context.session_status_result
+    context = described_class.new(
+      api_maker_args: {},
+      channel:,
+      request_fingerprint: "fingerprint-1",
+      request_uid: "request-1"
+    )
+
+    result = context.session_status_result
 
     expect(result).to include(
       devise: {timeout_in: Devise.timeout_in.to_i},
@@ -104,9 +113,8 @@ describe ApiMaker::ActionCableRequestContext do
     )
   end
 
-  it "sets current_user in api_maker_args from the channel" do
-    channel.define_singleton_method(:current_user) { @_test_user }
-    channel.instance_variable_set(:@_test_user, user)
+  it "sets current model in api_maker_args for all Devise scopes from warden" do
+    expect(warden).to receive(:user).with(:user).and_return(user)
 
     context = described_class.new(
       api_maker_args: {},

--- a/ruby-gem/spec/services/api_maker/action_cable_request_context_spec.rb
+++ b/ruby-gem/spec/services/api_maker/action_cable_request_context_spec.rb
@@ -27,7 +27,7 @@ describe ApiMaker::ActionCableRequestContext do
   let(:request_context) do
     allow(warden).to receive(:user).with(:user).and_return(nil)
 
-    described_class.new(
+    ApiMaker::ActionCableRequestContext.new(
       api_maker_args: {current_user: nil},
       channel:,
       request_fingerprint: "fingerprint-1",
@@ -90,10 +90,10 @@ describe ApiMaker::ActionCableRequestContext do
   end
 
   it "returns session status for the current websocket state" do
-    allow(warden).to receive(:user).with(:user).and_return(user)
+    expect(warden).to receive(:user).with(:user).and_return(user).twice
     expect(warden).to receive(:authenticated?).with(:user).and_return(true)
 
-    context = described_class.new(
+    context = ApiMaker::ActionCableRequestContext.new(
       api_maker_args: {},
       channel:,
       request_fingerprint: "fingerprint-1",
@@ -116,7 +116,7 @@ describe ApiMaker::ActionCableRequestContext do
   it "sets current model in api_maker_args for all Devise scopes from warden" do
     expect(warden).to receive(:user).with(:user).and_return(user)
 
-    context = described_class.new(
+    context = ApiMaker::ActionCableRequestContext.new(
       api_maker_args: {},
       channel:,
       request_fingerprint: "fingerprint-1",

--- a/ruby-gem/spec/services/api_maker/action_cable_request_context_spec.rb
+++ b/ruby-gem/spec/services/api_maker/action_cable_request_context_spec.rb
@@ -17,6 +17,7 @@ describe ApiMaker::ActionCableRequestContext do
     Object.new.tap do |object|
       object.define_singleton_method(:api_maker_locals) { {} }
       object.define_singleton_method(:connection) { connection_instance }
+      object.define_singleton_method(:current_user) { connection_instance.current_user }
       object.define_singleton_method(:current_session_id) { "session-1" }
       object.define_singleton_method(:update_api_maker_current_user!) do |_current_user|
         nil
@@ -101,6 +102,20 @@ describe ApiMaker::ActionCableRequestContext do
         }
       }
     )
+  end
+
+  it "sets current_user in api_maker_args from the channel" do
+    channel.define_singleton_method(:current_user) { @_test_user }
+    channel.instance_variable_set(:@_test_user, user)
+
+    context = described_class.new(
+      api_maker_args: {},
+      channel:,
+      request_fingerprint: "fingerprint-1",
+      request_uid: "request-1"
+    )
+
+    expect(context.api_maker_args[:current_user]).to eq(user)
   end
 
   it "stores itself as the controller in api_maker_args" do


### PR DESCRIPTION
## Summary

- Set `current_user: channel.current_user` in `ActionCableRequestContext#initialize` so resource abilities can read it from `api_maker_args[:current_user]`

## Problem

For HTTP requests, `ApplicationController#api_maker_args` includes `current_user: current_user`. For ActionCable requests, `ActionCableRequestContext` built `api_maker_args` without `current_user`. Resource abilities that read `api_maker_args[:current_user]` got `nil`, making `signed_in?` return `false` and denying access to the user's own records — even when the channel had a valid warden session.

This caused `NotFoundOrNoAccessError` on member commands (e.g. `Users::WeekBar`) when the frontend sent the command via WebSocket.

## Test plan

- [x] New spec: "sets current_user in api_maker_args from the channel"
- [x] All 10 existing ActionCableRequestContext specs pass
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)