### PR TITLE
Add JSDoc props and state types to ShapeComponents

### DIFF
--- a/npm-api-maker/src/base-component.jsx
+++ b/npm-api-maker/src/base-component.jsx
@@ -1,5 +1,10 @@
 import {ShapeComponent} from "set-state-compare/build/shape-component.js"
 
+/**
+ * @template Props
+ * @template State
+ * @augments {ShapeComponent<Props, State>}
+ */
 export default class BaseComponent extends ShapeComponent {
   // Nothing yet.
 }

--- a/npm-api-maker/src/base-component.jsx
+++ b/npm-api-maker/src/base-component.jsx
@@ -1,5 +1,0 @@
-import {ShapeComponent} from "set-state-compare/build/shape-component.js"
-
-export default class BaseComponent extends ShapeComponent {
-  // Nothing yet.
-}

--- a/npm-api-maker/src/base-component.jsx
+++ b/npm-api-maker/src/base-component.jsx
@@ -1,10 +1,5 @@
 import {ShapeComponent} from "set-state-compare/build/shape-component.js"
 
-/**
- * @template Props
- * @template State
- * @augments {ShapeComponent<Props, State>}
- */
 export default class BaseComponent extends ShapeComponent {
   // Nothing yet.
 }

--- a/npm-api-maker/src/bootstrap/attribute-row.jsx
+++ b/npm-api-maker/src/bootstrap/attribute-row.jsx
@@ -12,7 +12,9 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ApiMakerBootstrapAttributeRow extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapAttributeRow extends ShapeComponent {
   static defaultProps = {
     checkIfAttributeLoaded: false,
     defaultDateFormatName: undefined,

--- a/npm-api-maker/src/bootstrap/attribute-row.jsx
+++ b/npm-api-maker/src/bootstrap/attribute-row.jsx
@@ -12,8 +12,19 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {boolean=} checkIfAttributeLoaded
+ * @property {any=} children
+ * @property {Function|string=} defaultDateFormatName
+ * @property {Function|string=} defaultDateTimeFormatName
+ * @property {string=} identifier
+ * @property {any|string=} label
+ * @property {object=} model
+ * @property {any=} value
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapAttributeRow extends ShapeComponent {
   static defaultProps = {
     checkIfAttributeLoaded: false,

--- a/npm-api-maker/src/bootstrap/attribute-row.jsx
+++ b/npm-api-maker/src/bootstrap/attribute-row.jsx
@@ -34,7 +34,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
   static propTypes = {
     attribute: PropTypes.string,
-    checkIfAttributeLoaded: PropTypes.bool.isRequired,
+    checkIfAttributeLoaded: PropTypes.bool,
     children: PropTypes.any,
     defaultDateFormatName: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     defaultDateTimeFormatName: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),

--- a/npm-api-maker/src/bootstrap/attribute-rows.jsx
+++ b/npm-api-maker/src/bootstrap/attribute-rows.jsx
@@ -1,8 +1,7 @@
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import PropTypes from "prop-types" // eslint-disable-line sort-imports
 import React from "react"
 import AttributeRow from "./attribute-row" // eslint-disable-line sort-imports
-import BaseComponent from "../base-component"
 import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 
@@ -15,7 +14,7 @@ import propTypesExact from "prop-types-exact"
  * @property {object} model
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapAttributeRows extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapAttributeRows extends ShapeComponent {
   static defaultProps = {
     checkIfAttributeLoaded: false,
     defaultDateFormatName: undefined,

--- a/npm-api-maker/src/bootstrap/attribute-rows.jsx
+++ b/npm-api-maker/src/bootstrap/attribute-rows.jsx
@@ -23,7 +23,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
   static propTypes = propTypesExact({
     attributes: PropTypes.array.isRequired,
-    checkIfAttributeLoaded: PropTypes.bool.isRequired,
+    checkIfAttributeLoaded: PropTypes.bool,
     defaultDateFormatName: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     defaultDateTimeFormatName: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     model: PropTypes.object.isRequired

--- a/npm-api-maker/src/bootstrap/attribute-rows.jsx
+++ b/npm-api-maker/src/bootstrap/attribute-rows.jsx
@@ -6,8 +6,15 @@ import BaseComponent from "../base-component"
 import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any[]} attributes
+ * @property {boolean=} checkIfAttributeLoaded
+ * @property {Function|string=} defaultDateFormatName
+ * @property {Function|string=} defaultDateTimeFormatName
+ * @property {object} model
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapAttributeRows extends BaseComponent {
   static defaultProps = {
     checkIfAttributeLoaded: false,

--- a/npm-api-maker/src/bootstrap/attribute-rows.jsx
+++ b/npm-api-maker/src/bootstrap/attribute-rows.jsx
@@ -6,7 +6,9 @@ import BaseComponent from "../base-component"
 import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 
-export default memo(shapeComponent(class ApiMakerBootstrapAttributeRows extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapAttributeRows extends BaseComponent {
   static defaultProps = {
     checkIfAttributeLoaded: false,
     defaultDateFormatName: undefined,

--- a/npm-api-maker/src/bootstrap/card.jsx
+++ b/npm-api-maker/src/bootstrap/card.jsx
@@ -39,14 +39,14 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     children: PropTypes.any,
     className: PropTypes.string,
     controls: PropTypes.any,
-    defaultExpanded: PropTypes.bool.isRequired,
-    expandable: PropTypes.bool.isRequired,
-    expandableHide: PropTypes.bool.isRequired,
+    defaultExpanded: PropTypes.bool,
+    expandable: PropTypes.bool,
+    expandableHide: PropTypes.bool,
     footer: PropTypes.any,
     header: PropTypes.any,
-    responsiveTable: PropTypes.bool.isRequired,
+    responsiveTable: PropTypes.bool,
     striped: PropTypes.bool,
-    table: PropTypes.bool.isRequired
+    table: PropTypes.bool
   }
 
   state = {

--- a/npm-api-maker/src/bootstrap/card.jsx
+++ b/npm-api-maker/src/bootstrap/card.jsx
@@ -6,7 +6,9 @@ import PropTypes from "prop-types"
 import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import memo from "set-state-compare/build/memo.js"
 
-export default memo(shapeComponent(class ApiMakerBootstrapCard extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapCard extends BaseComponent {
   static defaultProps = {
     defaultExpanded: true,
     expandable: false,

--- a/npm-api-maker/src/bootstrap/card.jsx
+++ b/npm-api-maker/src/bootstrap/card.jsx
@@ -6,8 +6,25 @@ import PropTypes from "prop-types"
 import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import memo from "set-state-compare/build/memo.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} cardRef
+ * @property {any=} children
+ * @property {string=} className
+ * @property {any=} controls
+ * @property {boolean=} defaultExpanded
+ * @property {boolean=} expandable
+ * @property {boolean=} expandableHide
+ * @property {any=} footer
+ * @property {any=} header
+ * @property {boolean=} responsiveTable
+ * @property {boolean=} striped
+ * @property {boolean=} table
+ */
+/**
+ * @typedef {object} State
+ * @property {any} expanded
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapCard extends BaseComponent {
   static defaultProps = {
     defaultExpanded: true,

--- a/npm-api-maker/src/bootstrap/card.jsx
+++ b/npm-api-maker/src/bootstrap/card.jsx
@@ -1,9 +1,9 @@
+/* eslint-disable sort-imports */
 import React, {useRef} from "react"
 import {digg, digs} from "diggerize"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "../base-component" // eslint-disable-line sort-imports
-import PropTypes from "prop-types"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import classNames from "classnames" // eslint-disable-line import/no-unresolved
+import PropTypes from "prop-types"
 import memo from "set-state-compare/build/memo.js"
 
 /**
@@ -25,7 +25,7 @@ import memo from "set-state-compare/build/memo.js"
  * @typedef {object} State
  * @property {any} expanded
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapCard extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapCard extends ShapeComponent {
   static defaultProps = {
     defaultExpanded: true,
     expandable: false,

--- a/npm-api-maker/src/bootstrap/checkbox.jsx
+++ b/npm-api-maker/src/bootstrap/checkbox.jsx
@@ -8,8 +8,23 @@ import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import memo from "set-state-compare/build/memo.js"
 import useInput from "../use-input.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {string=} className
+ * @property {boolean=} defaultChecked
+ * @property {any=} defaultValue
+ * @property {any=} hint
+ * @property {string=} id
+ * @property {any=} label
+ * @property {string=} labelClassName
+ * @property {object=} model
+ * @property {string=} name
+ * @property {Function=} onChange
+ * @property {string=} wrapperClassName
+ * @property {boolean=} zeroInput
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapCheckbox extends ShapeComponent {
   static defaultProps = {
     defaultValue: 1,

--- a/npm-api-maker/src/bootstrap/checkbox.jsx
+++ b/npm-api-maker/src/bootstrap/checkbox.jsx
@@ -8,7 +8,9 @@ import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import memo from "set-state-compare/build/memo.js"
 import useInput from "../use-input.js"
 
-export default memo(shapeComponent(class ApiMakerBootstrapCheckbox extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapCheckbox extends ShapeComponent {
   static defaultProps = {
     defaultValue: 1,
     zeroInput: true

--- a/npm-api-maker/src/bootstrap/checkboxes.jsx
+++ b/npm-api-maker/src/bootstrap/checkboxes.jsx
@@ -9,8 +9,20 @@ import propTypesExact from "prop-types-exact"
 import {useForm} from "../form"
 import useInput from "../use-input.js"
 
-/** @typedef {object} OptionElementProps */
-/** @typedef {object} OptionElementState */
+/**
+ * @typedef {object} OptionElementProps
+ * @property {string} generatedId
+ * @property {string} inputCheckboxClassName
+ * @property {boolean} isDefaultSelected
+ * @property {string} inputName
+ * @property {Function=} onChange
+ * @property {Function} onOptionChecked
+ * @property {any[]} option
+ * @property {number} optionIndex
+ * @property {any[][]} options
+ * @property {object} wrapperOpts
+ */
+/** @typedef {Record<string, never>} OptionElementState */
 const OptionElement = memo(shapeComponent(/** @augments {ShapeComponent<OptionElementProps, OptionElementState>} */ class OptionElement extends ShapeComponent {
   render() {
     const {generatedId, inputCheckboxClassName, isDefaultSelected, inputName, option, optionIndex, options, wrapperOpts} = this.p
@@ -48,8 +60,21 @@ const OptionElement = memo(shapeComponent(/** @augments {ShapeComponent<OptionEl
   }
 }))
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {any[]=} defaultValue
+ * @property {string=} label
+ * @property {string=} labelClassName
+ * @property {object=} model
+ * @property {string=} name
+ * @property {Function=} onChange
+ * @property {any[][]} options
+ */
+/**
+ * @typedef {object} State
+ * @property {any} checkedOptions
+ */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapCheckboxes extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,

--- a/npm-api-maker/src/bootstrap/checkboxes.jsx
+++ b/npm-api-maker/src/bootstrap/checkboxes.jsx
@@ -9,7 +9,9 @@ import propTypesExact from "prop-types-exact"
 import {useForm} from "../form"
 import useInput from "../use-input.js"
 
-const OptionElement = memo(shapeComponent(class OptionElement extends ShapeComponent {
+/** @typedef {object} OptionElementProps */
+/** @typedef {object} OptionElementState */
+const OptionElement = memo(shapeComponent(/** @augments {ShapeComponent<OptionElementProps, OptionElementState>} */ class OptionElement extends ShapeComponent {
   render() {
     const {generatedId, inputCheckboxClassName, isDefaultSelected, inputName, option, optionIndex, options, wrapperOpts} = this.p
     const {errors} = digs(wrapperOpts, "errors")
@@ -46,7 +48,9 @@ const OptionElement = memo(shapeComponent(class OptionElement extends ShapeCompo
   }
 }))
 
-export default memo(shapeComponent(class ApiMakerBootstrapCheckboxes extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapCheckboxes extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,
     defaultValue: PropTypes.array,

--- a/npm-api-maker/src/bootstrap/input.jsx
+++ b/npm-api-maker/src/bootstrap/input.jsx
@@ -8,7 +8,9 @@ import React from "react"
 import inputWrapper from "../inputs/input-wrapper"
 import memo from "set-state-compare/build/memo.js"
 
-const ApiMakerBootstrapInput = memo(shapeComponent(class ApiMakerBootstrapInput extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+const ApiMakerBootstrapInput = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapInput extends ShapeComponent {
   static propTypes = {
     append: PropTypes.any,
     appendText: PropTypes.any,

--- a/npm-api-maker/src/bootstrap/input.jsx
+++ b/npm-api-maker/src/bootstrap/input.jsx
@@ -8,8 +8,29 @@ import React from "react"
 import inputWrapper from "../inputs/input-wrapper"
 import memo from "set-state-compare/build/memo.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any=} append
+ * @property {any=} appendText
+ * @property {string=} attribute
+ * @property {string=} className
+ * @property {any[]=} currenciesCollection
+ * @property {string=} currencyName
+ * @property {any=} hint
+ * @property {any=} hintBottom
+ * @property {string=} id
+ * @property {any=} label
+ * @property {string=} labelClassName
+ * @property {object=} model
+ * @property {string=} name
+ * @property {any=} placeholder
+ * @property {any=} prepend
+ * @property {any=} prependText
+ * @property {boolean=} small
+ * @property {string=} type
+ * @property {string=} wrapperClassName
+ */
+/** @typedef {Record<string, never>} State */
 const ApiMakerBootstrapInput = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapInput extends ShapeComponent {
   static propTypes = {
     append: PropTypes.any,

--- a/npm-api-maker/src/bootstrap/paginate.jsx
+++ b/npm-api-maker/src/bootstrap/paginate.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-return-assign */
 import React, {useMemo} from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "../base-component" // eslint-disable-line sort-imports
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Link from "../link"
 import PropTypes from "prop-types"
 import Result from "../result.js"
@@ -25,7 +24,7 @@ const ELLIPSIS_LABEL = "…"
  * @property {any|Result} result
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapPaginate extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapPaginate extends ShapeComponent {
   static propTypes = propTypesExact({
     result: PropTypes.oneOfType([
       instanceOfClassName("ApiMakerResult"),

--- a/npm-api-maker/src/bootstrap/paginate.jsx
+++ b/npm-api-maker/src/bootstrap/paginate.jsx
@@ -20,7 +20,9 @@ const NEXT_PAGE_LABEL = "→"
 const LAST_PAGE_LABEL = "⇥"
 const ELLIPSIS_LABEL = "…"
 
-export default memo(shapeComponent(class ApiMakerBootstrapPaginate extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapPaginate extends BaseComponent {
   static propTypes = propTypesExact({
     result: PropTypes.oneOfType([
       instanceOfClassName("ApiMakerResult"),

--- a/npm-api-maker/src/bootstrap/paginate.jsx
+++ b/npm-api-maker/src/bootstrap/paginate.jsx
@@ -20,8 +20,11 @@ const NEXT_PAGE_LABEL = "→"
 const LAST_PAGE_LABEL = "⇥"
 const ELLIPSIS_LABEL = "…"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any|Result} result
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapPaginate extends BaseComponent {
   static propTypes = propTypesExact({
     result: PropTypes.oneOfType([

--- a/npm-api-maker/src/bootstrap/sort-link.jsx
+++ b/npm-api-maker/src/bootstrap/sort-link.jsx
@@ -12,8 +12,17 @@ import urlEncode from "../url-encode.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import useSorting from "../table/use-sorting.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string} attribute
+ * @property {string=} className
+ * @property {object=} defaultParams
+ * @property {object=} linkComponent
+ * @property {Function=} onChanged
+ * @property {object} query
+ * @property {any=} title
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapSortLink extends BaseComponent {
   static propTypes = {
     attribute: PropTypes.string.isRequired,

--- a/npm-api-maker/src/bootstrap/sort-link.jsx
+++ b/npm-api-maker/src/bootstrap/sort-link.jsx
@@ -1,6 +1,5 @@
 import * as inflection from "inflection"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "../base-component" // eslint-disable-line sort-imports
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Icon from "../utils/icon"
 import Link from "../link"
 import PropTypes from "prop-types"
@@ -23,7 +22,7 @@ import useSorting from "../table/use-sorting.js"
  * @property {any=} title
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapSortLink extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootstrapSortLink extends ShapeComponent {
   static propTypes = {
     attribute: PropTypes.string.isRequired,
     className: PropTypes.string,

--- a/npm-api-maker/src/bootstrap/sort-link.jsx
+++ b/npm-api-maker/src/bootstrap/sort-link.jsx
@@ -12,7 +12,9 @@ import urlEncode from "../url-encode.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import useSorting from "../table/use-sorting.js"
 
-export default memo(shapeComponent(class ApiMakerBootstrapSortLink extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootstrapSortLink extends BaseComponent {
   static propTypes = {
     attribute: PropTypes.string.isRequired,
     className: PropTypes.string,

--- a/npm-api-maker/src/draggable-sort/index.jsx
+++ b/npm-api-maker/src/draggable-sort/index.jsx
@@ -10,7 +10,9 @@ import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 import useEventEmitter from "ya-use-event-emitter"
 
-export default memo(shapeComponent(class DraggableSort extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class DraggableSort extends ShapeComponent {
   /** @type {import("./controller.js").default} */
   controller
 

--- a/npm-api-maker/src/draggable-sort/index.jsx
+++ b/npm-api-maker/src/draggable-sort/index.jsx
@@ -10,8 +10,22 @@ import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 import useEventEmitter from "ya-use-event-emitter"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} activeItemStyle
+ * @property {Function=} cacheKeyExtractor
+ * @property {any[]} data
+ * @property {object=} dataSet
+ * @property {EventEmitter=} events
+ * @property {boolean=} horizontal
+ * @property {Function} keyExtractor
+ * @property {Function=} onDragItemEnd
+ * @property {Function=} onDragItemStart
+ * @property {Function=} onItemMoved
+ * @property {Function} onReordered
+ * @property {Function} renderItem
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class DraggableSort extends ShapeComponent {
   /** @type {import("./controller.js").default} */
   controller

--- a/npm-api-maker/src/draggable-sort/index.jsx
+++ b/npm-api-maker/src/draggable-sort/index.jsx
@@ -44,7 +44,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     data: PropTypes.array.isRequired,
     dataSet: PropTypes.object,
     events: PropTypes.instanceOf(EventEmitter),
-    horizontal: PropTypes.bool.isRequired,
+    horizontal: PropTypes.bool,
     keyExtractor: PropTypes.func.isRequired,
     onDragItemEnd: PropTypes.func,
     onDragItemStart: PropTypes.func,

--- a/npm-api-maker/src/draggable-sort/item.jsx
+++ b/npm-api-maker/src/draggable-sort/item.jsx
@@ -8,8 +8,21 @@ import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 import useEventEmitter from "ya-use-event-emitter"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} activeItemStyle
+ * @property {string=} cacheKey
+ * @property {object} controller
+ * @property {any} item
+ * @property {number} itemIndex
+ * @property {Function=} onItemMoved
+ * @property {Function} renderItem
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} active
+ * @property {boolean} dragging
+ */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class DraggableSortItem extends ShapeComponent {
   static propTypes = propTypesExact({
     activeItemStyle: PropTypes.object,

--- a/npm-api-maker/src/draggable-sort/item.jsx
+++ b/npm-api-maker/src/draggable-sort/item.jsx
@@ -8,7 +8,9 @@ import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 import useEventEmitter from "ya-use-event-emitter"
 
-export default memo(shapeComponent(class DraggableSortItem extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class DraggableSortItem extends ShapeComponent {
   static propTypes = propTypesExact({
     activeItemStyle: PropTypes.object,
     cacheKey: PropTypes.string,

--- a/npm-api-maker/src/event-connection.jsx
+++ b/npm-api-maker/src/event-connection.jsx
@@ -9,7 +9,7 @@ export default class ApiMakerEventConnection extends React.PureComponent {
   }
 
   static propTypes = propTypesExact({
-    active: PropTypes.bool.isRequired,
+    active: PropTypes.bool,
     model: PropTypes.object.isRequired,
     event: PropTypes.string.isRequired,
     onCall: PropTypes.func.isRequired

--- a/npm-api-maker/src/form.jsx
+++ b/npm-api-maker/src/form.jsx
@@ -1,9 +1,8 @@
 /* eslint-disable sort-imports */
 import React, {createContext, useContext, useEffect, useMemo} from "react"
 import {Platform} from "react-native"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import apiMakerConfig from "./config.js"
-import BaseComponent from "./base-component"
 import FormDataObjectizer from "form-data-objectizer"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
@@ -74,7 +73,7 @@ class FormInputs {
  * @property {boolean=} useHtmlForm
  */
 /** @typedef {Record<string, never>} State */
-const Form = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Form extends BaseComponent {
+const Form = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class Form extends ShapeComponent {
   static propTypes = propTypesExact({
     children: PropTypes.any,
     form: PropTypes.instanceOf(FormInputs),

--- a/npm-api-maker/src/form.jsx
+++ b/npm-api-maker/src/form.jsx
@@ -62,7 +62,9 @@ class FormInputs {
   }
 }
 
-const Form = memo(shapeComponent(class Form extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+const Form = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Form extends BaseComponent {
   static propTypes = propTypesExact({
     children: PropTypes.any,
     form: PropTypes.instanceOf(FormInputs),

--- a/npm-api-maker/src/form.jsx
+++ b/npm-api-maker/src/form.jsx
@@ -62,8 +62,18 @@ class FormInputs {
   }
 }
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any=} children
+ * @property {FormInputs=} form
+ * @property {object=} formObjectRef
+ * @property {object=} formRef
+ * @property {object=} htmlFormProps
+ * @property {Function=} onSubmit
+ * @property {Function=} setForm
+ * @property {boolean=} useHtmlForm
+ */
+/** @typedef {Record<string, never>} State */
 const Form = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Form extends BaseComponent {
   static propTypes = propTypesExact({
     children: PropTypes.any,

--- a/npm-api-maker/src/inputs/attachment.jsx
+++ b/npm-api-maker/src/inputs/attachment.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable sort-imports */
 import ApiMakerInput from "./input"
 import {digg} from "diggerize"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "../base-component"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Checkbox from "./checkbox"
 import PropTypes from "prop-types"
 import React from "react"
@@ -24,7 +23,7 @@ import useInput from "../use-input.js"
  * @typedef {object} State
  * @property {boolean} purgeChecked
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsAttachment extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerInputsAttachment extends ShapeComponent {
   static propTypes = {
     className: PropTypes.string,
     contentType: PropTypes.string,

--- a/npm-api-maker/src/inputs/attachment.jsx
+++ b/npm-api-maker/src/inputs/attachment.jsx
@@ -11,7 +11,9 @@ import memo from "set-state-compare/build/memo.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useInput from "../use-input.js"
 
-export default memo(shapeComponent(class ApiMakerInputsAttachment extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsAttachment extends BaseComponent {
   static propTypes = {
     className: PropTypes.string,
     contentType: PropTypes.string,

--- a/npm-api-maker/src/inputs/attachment.jsx
+++ b/npm-api-maker/src/inputs/attachment.jsx
@@ -11,8 +11,19 @@ import memo from "set-state-compare/build/memo.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useInput from "../use-input.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} className
+ * @property {string=} contentType
+ * @property {object=} model
+ * @property {Function=} onPurgeChanged
+ * @property {string=} purgeName
+ * @property {string=} url
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} purgeChecked
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsAttachment extends BaseComponent {
   static propTypes = {
     className: PropTypes.string,

--- a/npm-api-maker/src/inputs/checkbox.jsx
+++ b/npm-api-maker/src/inputs/checkbox.jsx
@@ -10,7 +10,9 @@ import memo from "set-state-compare/build/memo.js"
 import useInput from "../use-input.js"
 import useUpdatedEvent from "../use-updated-event.js"
 
-export default memo(shapeComponent(class ApiMakerInputsCheckbox extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsCheckbox extends BaseComponent {
   static defaultProps = {
     autoRefresh: false,
     autoSubmit: false,

--- a/npm-api-maker/src/inputs/checkbox.jsx
+++ b/npm-api-maker/src/inputs/checkbox.jsx
@@ -36,8 +36,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
   static propTypes = {
     attribute: PropTypes.string,
-    autoRefresh: PropTypes.bool.isRequired,
-    autoSubmit: PropTypes.bool.isRequired,
+    autoRefresh: PropTypes.bool,
+    autoSubmit: PropTypes.bool,
     defaultChecked: PropTypes.bool,
     defaultValue: PropTypes.any,
     id: PropTypes.string,

--- a/npm-api-maker/src/inputs/checkbox.jsx
+++ b/npm-api-maker/src/inputs/checkbox.jsx
@@ -10,8 +10,22 @@ import memo from "set-state-compare/build/memo.js"
 import useInput from "../use-input.js"
 import useUpdatedEvent from "../use-updated-event.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {boolean=} autoRefresh
+ * @property {boolean=} autoSubmit
+ * @property {boolean=} defaultChecked
+ * @property {any=} defaultValue
+ * @property {string=} id
+ * @property {object=} inputRef
+ * @property {object=} model
+ * @property {string=} name
+ * @property {Function=} onErrors
+ * @property {Function=} onMatchValidationError
+ * @property {boolean=} zeroInput
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsCheckbox extends BaseComponent {
   static defaultProps = {
     autoRefresh: false,

--- a/npm-api-maker/src/inputs/checkbox.jsx
+++ b/npm-api-maker/src/inputs/checkbox.jsx
@@ -1,10 +1,9 @@
 /* eslint-disable sort-imports */
 import React, {useMemo} from "react"
 import {digg} from "diggerize"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useForm} from "../form"
 import AutoSubmit from "./auto-submit.js"
-import BaseComponent from "../base-component"
 import PropTypes from "prop-types"
 import memo from "set-state-compare/build/memo.js"
 import useInput from "../use-input.js"
@@ -26,7 +25,7 @@ import useUpdatedEvent from "../use-updated-event.js"
  * @property {boolean=} zeroInput
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsCheckbox extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerInputsCheckbox extends ShapeComponent {
   static defaultProps = {
     autoRefresh: false,
     autoSubmit: false,

--- a/npm-api-maker/src/inputs/checkboxes.jsx
+++ b/npm-api-maker/src/inputs/checkboxes.jsx
@@ -11,8 +11,20 @@ import inputWrapper from "./input-wrapper"
 import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {any[]=} defaultValue
+ * @property {string=} id
+ * @property {object} inputProps
+ * @property {any=} label
+ * @property {object=} model
+ * @property {string=} name
+ * @property {Function=} onChange
+ * @property {any[]} options
+ * @property {object=} wrapperOpts
+ */
+/** @typedef {Record<string, never>} State */
 const ApiMakerInputsCheckboxes = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsCheckboxes extends BaseComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,

--- a/npm-api-maker/src/inputs/checkboxes.jsx
+++ b/npm-api-maker/src/inputs/checkboxes.jsx
@@ -11,7 +11,9 @@ import inputWrapper from "./input-wrapper"
 import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
 
-const ApiMakerInputsCheckboxes = memo(shapeComponent(class ApiMakerInputsCheckboxes extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+const ApiMakerInputsCheckboxes = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsCheckboxes extends BaseComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,
     defaultValue: PropTypes.array,

--- a/npm-api-maker/src/inputs/checkboxes.jsx
+++ b/npm-api-maker/src/inputs/checkboxes.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable sort-imports */
 import * as inflection from "inflection"
 import {digs} from "diggerize"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "../base-component"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import InvalidFeedback from "../bootstrap/invalid-feedback"
 import PropTypes from "prop-types"
 import React from "react"
@@ -25,7 +24,7 @@ import propTypesExact from "prop-types-exact"
  * @property {object=} wrapperOpts
  */
 /** @typedef {Record<string, never>} State */
-const ApiMakerInputsCheckboxes = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsCheckboxes extends BaseComponent {
+const ApiMakerInputsCheckboxes = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerInputsCheckboxes extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,
     defaultValue: PropTypes.array,

--- a/npm-api-maker/src/inputs/input.jsx
+++ b/npm-api-maker/src/inputs/input.jsx
@@ -14,7 +14,9 @@ import strftime from "strftime"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useUpdatedEvent from "../use-updated-event.js"
 
-const ApiMakerInputsInput = memo(shapeComponent(class ApiMakerInputsInput extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+const ApiMakerInputsInput = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsInput extends BaseComponent {
   static defaultProps = {
     autoRefresh: false,
     autoSubmit: false,

--- a/npm-api-maker/src/inputs/input.jsx
+++ b/npm-api-maker/src/inputs/input.jsx
@@ -1,10 +1,9 @@
 /* eslint-disable sort-imports */
 import React, {useMemo, useRef} from "react"
 import {dig, digg, digs} from "diggerize"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useForm} from "../form"
 import AutoSubmit from "./auto-submit.js"
-import BaseComponent from "../base-component"
 import Money from "./money"
 import PropTypes from "prop-types"
 import inputWrapper from "./input-wrapper"
@@ -33,7 +32,7 @@ import useUpdatedEvent from "../use-updated-event.js"
  * @typedef {object} State
  * @property {any} blankInputName
  */
-const ApiMakerInputsInput = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsInput extends BaseComponent {
+const ApiMakerInputsInput = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerInputsInput extends ShapeComponent {
   static defaultProps = {
     autoRefresh: false,
     autoSubmit: false,

--- a/npm-api-maker/src/inputs/input.jsx
+++ b/npm-api-maker/src/inputs/input.jsx
@@ -42,12 +42,12 @@ const ApiMakerInputsInput = memo(shapeComponent(/** @augments {ShapeComponent<Pr
 
   static propTypes = {
     attribute: PropTypes.string,
-    autoRefresh: PropTypes.bool.isRequired,
-    autoSubmit: PropTypes.bool.isRequired,
+    autoRefresh: PropTypes.bool,
+    autoSubmit: PropTypes.bool,
     className: PropTypes.string,
     formatValue: PropTypes.func,
     id: PropTypes.string,
-    localizedNumber: PropTypes.bool.isRequired,
+    localizedNumber: PropTypes.bool,
     model: PropTypes.object,
     name: PropTypes.string,
     onChange: PropTypes.func,

--- a/npm-api-maker/src/inputs/input.jsx
+++ b/npm-api-maker/src/inputs/input.jsx
@@ -14,8 +14,25 @@ import strftime from "strftime"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useUpdatedEvent from "../use-updated-event.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {boolean=} autoRefresh
+ * @property {boolean=} autoSubmit
+ * @property {string=} className
+ * @property {Function=} formatValue
+ * @property {string=} id
+ * @property {boolean=} localizedNumber
+ * @property {object=} model
+ * @property {string=} name
+ * @property {Function=} onChange
+ * @property {Function=} onMatchValidationError
+ * @property {string=} type
+ */
+/**
+ * @typedef {object} State
+ * @property {any} blankInputName
+ */
 const ApiMakerInputsInput = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsInput extends BaseComponent {
   static defaultProps = {
     autoRefresh: false,

--- a/npm-api-maker/src/inputs/money.jsx
+++ b/npm-api-maker/src/inputs/money.jsx
@@ -11,8 +11,8 @@ import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import idForComponent from "./id-for-component.js"
 import memo from "set-state-compare/build/memo.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerInputsMoney extends ShapeComponent {
   static defaultProps = {
     disabled: false,

--- a/npm-api-maker/src/inputs/money.jsx
+++ b/npm-api-maker/src/inputs/money.jsx
@@ -27,7 +27,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     currencyName: PropTypes.string,
     currencyRef: PropTypes.object,
     defaultValue: PropTypes.object,
-    disabled: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool,
     id: PropTypes.string,
     inputRef: PropTypes.object,
     label: PropTypes.any,

--- a/npm-api-maker/src/inputs/money.jsx
+++ b/npm-api-maker/src/inputs/money.jsx
@@ -11,7 +11,9 @@ import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import idForComponent from "./id-for-component.js"
 import memo from "set-state-compare/build/memo.js"
 
-export default memo(shapeComponent(class ApiMakerInputsMoney extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerInputsMoney extends ShapeComponent {
   static defaultProps = {
     disabled: false,
     showCurrencyOptions: true

--- a/npm-api-maker/src/inputs/select.jsx
+++ b/npm-api-maker/src/inputs/select.jsx
@@ -7,7 +7,9 @@ import React from "react"
 import inputWrapper from "./input-wrapper"
 import memo from "set-state-compare/build/memo.js"
 
-const ApiMakerInputsSelect = memo(shapeComponent(class ApiMakerInputsSelect extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+const ApiMakerInputsSelect = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsSelect extends BaseComponent {
   static propTypes = {
     attribute: PropTypes.string,
     children: PropTypes.any,

--- a/npm-api-maker/src/inputs/select.jsx
+++ b/npm-api-maker/src/inputs/select.jsx
@@ -7,8 +7,21 @@ import React from "react"
 import inputWrapper from "./input-wrapper"
 import memo from "set-state-compare/build/memo.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {any=} children
+ * @property {any[]|number|string=} defaultValue
+ * @property {string=} id
+ * @property {boolean|any=} includeBlank
+ * @property {object} inputProps
+ * @property {object=} model
+ * @property {string=} name
+ * @property {Function=} onChange
+ * @property {any[]=} options
+ * @property {object} wrapperOpts
+ */
+/** @typedef {Record<string, never>} State */
 const ApiMakerInputsSelect = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsSelect extends BaseComponent {
   static propTypes = {
     attribute: PropTypes.string,

--- a/npm-api-maker/src/inputs/select.jsx
+++ b/npm-api-maker/src/inputs/select.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable sort-imports */
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useForm} from "../form"
-import BaseComponent from "../base-component"
 import PropTypes from "prop-types"
 import React from "react"
 import inputWrapper from "./input-wrapper"
@@ -22,7 +21,7 @@ import memo from "set-state-compare/build/memo.js"
  * @property {object} wrapperOpts
  */
 /** @typedef {Record<string, never>} State */
-const ApiMakerInputsSelect = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerInputsSelect extends BaseComponent {
+const ApiMakerInputsSelect = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerInputsSelect extends ShapeComponent {
   static propTypes = {
     attribute: PropTypes.string,
     children: PropTypes.any,

--- a/npm-api-maker/src/link.jsx
+++ b/npm-api-maker/src/link.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable sort-imports */
 import {Platform, Pressable, StyleSheet} from "react-native"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "./base-component"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import PropTypes from "prop-types"
 import React from "react"
 import dataSetToAttributes from "./data-set-to-attributes.js"
@@ -15,7 +14,7 @@ import {useApiMaker} from "./with-api-maker"
  * @property {boolean=} usePressable
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerLink extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerLink extends ShapeComponent {
   static propTypes = {
     paddingHorizontal: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     paddingVertical: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/npm-api-maker/src/link.jsx
+++ b/npm-api-maker/src/link.jsx
@@ -8,7 +8,9 @@ import dataSetToAttributes from "./data-set-to-attributes.js"
 import memo from "set-state-compare/build/memo.js"
 import {useApiMaker} from "./with-api-maker"
 
-export default memo(shapeComponent(class ApiMakerLink extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerLink extends BaseComponent {
   static propTypes = {
     paddingHorizontal: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     paddingVertical: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/npm-api-maker/src/link.jsx
+++ b/npm-api-maker/src/link.jsx
@@ -8,8 +8,13 @@ import dataSetToAttributes from "./data-set-to-attributes.js"
 import memo from "set-state-compare/build/memo.js"
 import {useApiMaker} from "./with-api-maker"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {number|string=} paddingHorizontal
+ * @property {number|string=} paddingVertical
+ * @property {boolean=} usePressable
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerLink extends BaseComponent {
   static propTypes = {
     paddingHorizontal: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/npm-api-maker/src/modal.jsx
+++ b/npm-api-maker/src/modal.jsx
@@ -5,8 +5,8 @@ import BaseComponent from "./base-component"
 import React from "react"
 import memo from "set-state-compare/build/memo.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerModal extends BaseComponent {
   render() {
     const {children, onRequestClose, ...restProps} = this.props

--- a/npm-api-maker/src/modal.jsx
+++ b/npm-api-maker/src/modal.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable sort-imports */
 import {Modal, Pressable, View} from "react-native"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "./base-component"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import React from "react"
 import memo from "set-state-compare/build/memo.js"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerModal extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerModal extends ShapeComponent {
   render() {
     const {children, onRequestClose, ...restProps} = this.props
 

--- a/npm-api-maker/src/modal.jsx
+++ b/npm-api-maker/src/modal.jsx
@@ -5,7 +5,9 @@ import BaseComponent from "./base-component"
 import React from "react"
 import memo from "set-state-compare/build/memo.js"
 
-export default memo(shapeComponent(class ApiMakerModal extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerModal extends BaseComponent {
   render() {
     const {children, onRequestClose, ...restProps} = this.props
 

--- a/npm-api-maker/src/router.jsx
+++ b/npm-api-maker/src/router.jsx
@@ -7,8 +7,16 @@ import propTypesExact from "prop-types-exact"
 import usePath from "on-location-changed/build/use-path.js"
 import useRouter from "./use-router"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} history
+ * @property {any[]} locales
+ * @property {React.ComponentType<any>=} notFoundComponent
+ * @property {Function} requireComponent
+ * @property {object=} routeDefinitions
+ * @property {object=} routes
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerRouter extends BaseComponent {
   static propTypes = propTypesExact({
     history: PropTypes.object,

--- a/npm-api-maker/src/router.jsx
+++ b/npm-api-maker/src/router.jsx
@@ -7,7 +7,9 @@ import propTypesExact from "prop-types-exact"
 import usePath from "on-location-changed/build/use-path.js"
 import useRouter from "./use-router"
 
-export default memo(shapeComponent(class ApiMakerRouter extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerRouter extends BaseComponent {
   static propTypes = propTypesExact({
     history: PropTypes.object,
     locales: PropTypes.array.isRequired,

--- a/npm-api-maker/src/router.jsx
+++ b/npm-api-maker/src/router.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable sort-imports */
 import React, {Suspense, memo} from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "./base-component"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import usePath from "on-location-changed/build/use-path.js"
@@ -17,7 +16,7 @@ import useRouter from "./use-router"
  * @property {object=} routes
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerRouter extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerRouter extends ShapeComponent {
   static propTypes = propTypesExact({
     history: PropTypes.object,
     locales: PropTypes.array.isRequired,

--- a/npm-api-maker/src/router/route.jsx
+++ b/npm-api-maker/src/router/route.jsx
@@ -15,8 +15,24 @@ const RequireComponentContext = createContext(null)
 const RouteContext = createContext(null)
 const useParams = () => useContext(ParamsContext)
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any=} children
+ * @property {string=} component
+ * @property {string=} componentPath
+ * @property {boolean=} exact
+ * @property {boolean=} fallback
+ * @property {boolean=} includeInPath
+ * @property {Function=} onMatch
+ * @property {string|RegExp=} path
+ */
+/**
+ * @typedef {object} State
+ * @property {any} Component
+ * @property {any} componentNotFound
+ * @property {number} lastMatchUpdate
+ * @property {boolean} matches
+ */
 const Route = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Route extends BaseComponent {
   static defaultProps = {
     exact: false,

--- a/npm-api-maker/src/router/route.jsx
+++ b/npm-api-maker/src/router/route.jsx
@@ -43,9 +43,9 @@ const Route = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} *
     children: PropTypes.any,
     component: PropTypes.string,
     componentPath: PropTypes.string,
-    exact: PropTypes.bool.isRequired,
-    fallback: PropTypes.bool.isRequired,
-    includeInPath: PropTypes.bool.isRequired,
+    exact: PropTypes.bool,
+    fallback: PropTypes.bool,
+    includeInPath: PropTypes.bool,
     onMatch: PropTypes.func,
     path: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)])
   })

--- a/npm-api-maker/src/router/route.jsx
+++ b/npm-api-maker/src/router/route.jsx
@@ -15,7 +15,9 @@ const RequireComponentContext = createContext(null)
 const RouteContext = createContext(null)
 const useParams = () => useContext(ParamsContext)
 
-const Route = memo(shapeComponent(class Route extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+const Route = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Route extends BaseComponent {
   static defaultProps = {
     exact: false,
     fallback: false,

--- a/npm-api-maker/src/router/route.jsx
+++ b/npm-api-maker/src/router/route.jsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/jsx-max-depth, sort-imports */
 import React, {createContext, useContext, useEffect, useLayoutEffect, useMemo} from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Switch, {CurrentSwitchContext} from "./switch"
 import {arrayDifferent, simpleObjectDifferent} from "set-state-compare/build/diff-utils.js"
-import BaseComponent from "../base-component"
 import PropTypes from "prop-types"
 import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
@@ -33,7 +32,7 @@ const useParams = () => useContext(ParamsContext)
  * @property {number} lastMatchUpdate
  * @property {boolean} matches
  */
-const Route = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Route extends BaseComponent {
+const Route = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class Route extends ShapeComponent {
   static defaultProps = {
     exact: false,
     fallback: false,

--- a/npm-api-maker/src/router/switch.jsx
+++ b/npm-api-maker/src/router/switch.jsx
@@ -8,7 +8,9 @@ import propTypesExact from "prop-types-exact"
 
 const CurrentSwitchContext = createContext(/** @type {any} */ ({}))
 
-const Switch = memo(shapeComponent(class Switch extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+const Switch = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Switch extends BaseComponent {
   static defaultProps = {
     name: "[no name]",
     single: true

--- a/npm-api-maker/src/router/switch.jsx
+++ b/npm-api-maker/src/router/switch.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable sort-imports */
 import React, {createContext} from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "../base-component"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import PropTypes from "prop-types"
 import memo from "set-state-compare/build/memo.js"
 import propTypesExact from "prop-types-exact"
@@ -20,7 +19,7 @@ const CurrentSwitchContext = createContext(/** @type {any} */ ({}))
  * @property {any} pathShown
  * @property {object} pathsMatched
  */
-const Switch = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Switch extends BaseComponent {
+const Switch = memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class Switch extends ShapeComponent {
   static defaultProps = {
     name: "[no name]",
     single: true

--- a/npm-api-maker/src/router/switch.jsx
+++ b/npm-api-maker/src/router/switch.jsx
@@ -8,8 +8,18 @@ import propTypesExact from "prop-types-exact"
 
 const CurrentSwitchContext = createContext(/** @type {any} */ ({}))
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any=} children
+ * @property {string=} name
+ * @property {boolean=} single
+ */
+/**
+ * @typedef {object} State
+ * @property {Date} lastUpdate
+ * @property {any} pathShown
+ * @property {object} pathsMatched
+ */
 const Switch = memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class Switch extends BaseComponent {
   static defaultProps = {
     name: "[no name]",

--- a/npm-api-maker/src/super-admin/edit-page.jsx
+++ b/npm-api-maker/src/super-admin/edit-page.jsx
@@ -21,7 +21,9 @@ import propTypesExact from "prop-types-exact"
 import useCurrentUser from "../use-current-user.js"
 import useModel from "../use-model.js"
 
-export default memo(shapeComponent(class ApiMakerSuperAdminEditPage extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminEditPage extends BaseComponent {
   static propTypes = propTypesExact({
     modelClass: PropTypes.func.isRequired,
     modelId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])

--- a/npm-api-maker/src/super-admin/edit-page.jsx
+++ b/npm-api-maker/src/super-admin/edit-page.jsx
@@ -21,8 +21,12 @@ import propTypesExact from "prop-types-exact"
 import useCurrentUser from "../use-current-user.js"
 import useModel from "../use-model.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {Function} modelClass
+ * @property {number|string=} modelId
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminEditPage extends BaseComponent {
   static propTypes = propTypesExact({
     modelClass: PropTypes.func.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page.jsx
+++ b/npm-api-maker/src/super-admin/edit-page.jsx
@@ -6,8 +6,7 @@ import FormDataObjectizer from "form-data-objectizer"
 import {incorporate} from "incorporator"
 import {Pressable, View} from "react-native"
 import {digg} from "diggerize"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import BaseComponent from "../base-component"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import ConfigReader from "./config-reader"
 import EditAttribute from "./edit-page/edit-attribute"
 // @ts-expect-error
@@ -27,7 +26,7 @@ import useModel from "../use-model.js"
  * @property {number|string=} modelId
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminEditPage extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminEditPage extends ShapeComponent {
   static propTypes = propTypesExact({
     modelClass: PropTypes.func.isRequired,
     modelId: PropTypes.oneOfType([PropTypes.number, PropTypes.string])

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-checkbox.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-checkbox.jsx
@@ -15,8 +15,18 @@ const styles = StyleSheet.create({
   }
 })
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string} attributeName
+ * @property {string} id
+ * @property {string} label
+ * @property {object} model
+ * @property {string} name
+ */
+/**
+ * @typedef {object} State
+ * @property {any} checked
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeInput extends BaseComponent {
   static propTypes = propTypesExact({
     attributeName: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-checkbox.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-checkbox.jsx
@@ -15,7 +15,9 @@ const styles = StyleSheet.create({
   }
 })
 
-export default memo(shapeComponent(class EditAttributeInput extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeInput extends BaseComponent {
   static propTypes = propTypesExact({
     attributeName: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-checkbox.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-checkbox.jsx
@@ -2,11 +2,10 @@
 import React, {useEffect, useMemo} from "react"
 import {StyleSheet, View} from "react-native"
 import Checkbox from "../../utils/checkbox"
-import BaseComponent from "../../base-component"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useForm} from "../../form"
 
 const styles = StyleSheet.create({
@@ -27,7 +26,7 @@ const styles = StyleSheet.create({
  * @typedef {object} State
  * @property {any} checked
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeInput extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class EditAttributeInput extends ShapeComponent {
   static propTypes = propTypesExact({
     attributeName: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-content.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-content.jsx
@@ -7,7 +7,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useForm} from "../../form"
 import {useEffect, useMemo} from "react"
 
-export default memo(shapeComponent(class EditAttributeContent extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeContent extends BaseComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-content.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-content.jsx
@@ -7,8 +7,17 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useForm} from "../../form"
 import {useEffect, useMemo} from "react"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object} attribute
+ * @property {string} id
+ * @property {object} model
+ * @property {string} name
+ */
+/**
+ * @typedef {object} State
+ * @property {any} value
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeContent extends BaseComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.object.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-content.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-content.jsx
@@ -1,9 +1,8 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../../base-component"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useForm} from "../../form"
 import {useEffect, useMemo} from "react"
 
@@ -18,7 +17,7 @@ import {useEffect, useMemo} from "react"
  * @typedef {object} State
  * @property {any} value
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeContent extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class EditAttributeContent extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-input.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-input.jsx
@@ -9,7 +9,9 @@ import Text from "../../utils/text"
 import {useForm} from "../../form"
 import {TextInput, View} from "react-native"
 
-export default memo(shapeComponent(class EditAttributeInput extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeInput extends BaseComponent {
   static propTypes = propTypesExact({
     attributeName: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-input.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-input.jsx
@@ -9,8 +9,15 @@ import Text from "../../utils/text"
 import {useForm} from "../../form"
 import {TextInput, View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string} attributeName
+ * @property {string} id
+ * @property {string} label
+ * @property {object} model
+ * @property {string} name
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeInput extends BaseComponent {
   static propTypes = propTypesExact({
     attributeName: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute-input.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute-input.jsx
@@ -1,10 +1,9 @@
 /* eslint-disable sort-imports */
 import React, {useEffect} from "react"
-import BaseComponent from "../../base-component"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 import {useForm} from "../../form"
 import {TextInput, View} from "react-native"
@@ -18,7 +17,7 @@ import {TextInput, View} from "react-native"
  * @property {string} name
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttributeInput extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class EditAttributeInput extends ShapeComponent {
   static propTypes = propTypesExact({
     attributeName: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute.jsx
@@ -14,8 +14,13 @@ import React from "react"
 import {View} from "react-native"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object} attribute
+ * @property {object=} model
+ * @property {Function=} modelClass
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttribute extends BaseComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.object.isRequired,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../../base-component"
 import {digg} from "diggerize"
 import EditAttributeCheckbox from "./edit-attribute-checkbox"
 import EditAttributeContent from "./edit-attribute-content"
@@ -12,7 +11,7 @@ import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import React from "react"
 import {View} from "react-native"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 
 /**
  * @typedef {object} Props
@@ -21,7 +20,7 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
  * @property {Function=} modelClass
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttribute extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class EditAttribute extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.object.isRequired,
     model: PropTypes.object,

--- a/npm-api-maker/src/super-admin/edit-page/edit-attribute.jsx
+++ b/npm-api-maker/src/super-admin/edit-page/edit-attribute.jsx
@@ -14,7 +14,9 @@ import React from "react"
 import {View} from "react-native"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 
-export default memo(shapeComponent(class EditAttribute extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class EditAttribute extends BaseComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.object.isRequired,
     model: PropTypes.object,

--- a/npm-api-maker/src/super-admin/index-page.jsx
+++ b/npm-api-maker/src/super-admin/index-page.jsx
@@ -7,8 +7,11 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {Function} modelClass
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminIndexPage extends BaseComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired

--- a/npm-api-maker/src/super-admin/index-page.jsx
+++ b/npm-api-maker/src/super-admin/index-page.jsx
@@ -7,7 +7,9 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {View} from "react-native"
 
-export default memo(shapeComponent(class ApiMakerSuperAdminIndexPage extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminIndexPage extends BaseComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired
   }

--- a/npm-api-maker/src/super-admin/index-page.jsx
+++ b/npm-api-maker/src/super-admin/index-page.jsx
@@ -1,10 +1,9 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../base-component"
 import memo from "set-state-compare/build/memo.js"
 import ModelClassTable from "./model-class-table"
 import PropTypes from "prop-types"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {View} from "react-native"
 
 /**
@@ -12,7 +11,7 @@ import {View} from "react-native"
  * @property {Function} modelClass
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminIndexPage extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminIndexPage extends ShapeComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired
   }

--- a/npm-api-maker/src/super-admin/index.jsx
+++ b/npm-api-maker/src/super-admin/index.jsx
@@ -44,8 +44,11 @@ const styles = StyleSheet.create({
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/**
+ * @typedef {object} State
+ * @property {any} model
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdmin extends BaseComponent {
   loadModelRequestId = 0
   state = {

--- a/npm-api-maker/src/super-admin/index.jsx
+++ b/npm-api-maker/src/super-admin/index.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-return-assign, react/jsx-no-literals, react/jsx-no-useless-fragment, react/jsx-one-expression-per-line, sort-imports */
 import React, {useEffect, useMemo} from "react"
 import {Pressable, StyleSheet, View} from "react-native"
-import BaseComponent from "../base-component"
 import ConfigReader from "./config-reader"
 import EditPage from "./edit-page"
 import FlashNotifications from "flash-notifications/build/flash-notifications.js"
@@ -13,7 +12,7 @@ import memo from "set-state-compare/build/memo.js"
 // @ts-expect-error
 import * as models from "models.js" // eslint-disable-line import/no-unresolved
 import Params from "../params.js"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import ShowPage from "./show-page/index"
 import ShowReflectionActions from "./show-reflection-actions"
 import ShowReflectionPage from "./show-reflection-page"
@@ -49,7 +48,7 @@ const dataSets = {}
  * @typedef {object} State
  * @property {any} model
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdmin extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdmin extends ShapeComponent {
   loadModelRequestId = 0
   state = {
     model: undefined

--- a/npm-api-maker/src/super-admin/index.jsx
+++ b/npm-api-maker/src/super-admin/index.jsx
@@ -44,7 +44,9 @@ const styles = StyleSheet.create({
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ApiMakerSuperAdmin extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdmin extends BaseComponent {
   loadModelRequestId = 0
   state = {
     model: undefined

--- a/npm-api-maker/src/super-admin/layout/header/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/header/index.jsx
@@ -1,11 +1,10 @@
 /* eslint-disable indent, no-return-assign, sort-imports */
 import React, {useCallback, useRef} from "react"
-import BaseComponent from "../../../base-component"
 import Icon from "../../../utils/icon"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../../utils/text"
 import {Pressable, View} from "react-native"
 import {useBreakpoint} from "responsive-breakpoints"
@@ -49,7 +48,7 @@ export const useHeaderActionButtonStyle = () => {
  * @typedef {object} State
  * @property {boolean} headerActionsActive
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminLayoutHeader extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminLayoutHeader extends ShapeComponent {
   static propTypes = PropTypesExact({ // eslint-disable-line new-cap
     actions: PropTypes.any,
     onTriggerMenu: PropTypes.func.isRequired,

--- a/npm-api-maker/src/super-admin/layout/header/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/header/index.jsx
@@ -44,8 +44,11 @@ export const useHeaderActionButtonStyle = () => {
   }, [mdUp])
 }
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/**
+ * @typedef {object} State
+ * @property {boolean} headerActionsActive
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminLayoutHeader extends BaseComponent {
   static propTypes = PropTypesExact({ // eslint-disable-line new-cap
     actions: PropTypes.any,

--- a/npm-api-maker/src/super-admin/layout/header/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/header/index.jsx
@@ -44,7 +44,9 @@ export const useHeaderActionButtonStyle = () => {
   }, [mdUp])
 }
 
-export default memo(shapeComponent(class ApiMakerSuperAdminLayoutHeader extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminLayoutHeader extends BaseComponent {
   static propTypes = PropTypesExact({ // eslint-disable-line new-cap
     actions: PropTypes.any,
     onTriggerMenu: PropTypes.func.isRequired,

--- a/npm-api-maker/src/super-admin/layout/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/index.jsx
@@ -56,7 +56,9 @@ const styles = {
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ApiMakerSuperAdminLayout extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminLayout extends BaseComponent {
   static propTypes = PropTypesExact({ // eslint-disable-line new-cap
     actions: PropTypes.any,
     active: PropTypes.string,

--- a/npm-api-maker/src/super-admin/layout/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/index.jsx
@@ -56,8 +56,22 @@ const styles = {
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any=} actions
+ * @property {string=} active
+ * @property {any=} children
+ * @property {string=} className
+ * @property {object=} currentCustomer
+ * @property {string=} currentCustomerId
+ * @property {object=} currentUser
+ * @property {string=} headTitle
+ * @property {string=} headerTitle
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} menuTriggered
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminLayout extends BaseComponent {
   static propTypes = PropTypesExact({ // eslint-disable-line new-cap
     actions: PropTypes.any,

--- a/npm-api-maker/src/super-admin/layout/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/index.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-return-assign, react/jsx-closing-bracket-location, sort-imports */
 import React, {useMemo} from "react"
 import {View} from "react-native"
-import BaseComponent from "../../base-component"
 import CommandsPool from "../../commands-pool.js"
 // @ts-expect-error Runtime-resolved module
 import config from "super-admin/config" // eslint-disable-line import/no-unresolved
@@ -10,7 +9,7 @@ import memo from "set-state-compare/build/memo.js"
 import Menu from "./menu/index"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 import {useBreakpoint} from "responsive-breakpoints"
 import useCurrentUser from "../../use-current-user.js"
@@ -72,7 +71,7 @@ const dataSets = {}
  * @typedef {object} State
  * @property {boolean} menuTriggered
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminLayout extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminLayout extends ShapeComponent {
   static propTypes = PropTypesExact({ // eslint-disable-line new-cap
     actions: PropTypes.any,
     active: PropTypes.string,

--- a/npm-api-maker/src/super-admin/layout/menu/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/index.jsx
@@ -22,7 +22,9 @@ import {WithDefaultStyle} from "../../../utils/default-style"
 const dataSets = {}
 const styles = {}
 
-export default memo(shapeComponent(class ComponentsAdminLayoutMenu extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenu extends BaseComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.string,
     noAccess: PropTypes.bool.isRequired,

--- a/npm-api-maker/src/super-admin/layout/menu/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/index.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable new-cap, no-return-assign, react/jsx-max-depth, react/jsx-no-literals, sort-imports */
 import {View} from "react-native"
-import BaseComponent from "../../../base-component"
 import Devise from "../../../devise.js"
 import {FlashNotifications} from "flash-notifications"
 import Icon from "../../../utils/icon"
@@ -12,7 +11,7 @@ import Params from "../../../params.js"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../../utils/text"
 import {useBreakpoint} from "responsive-breakpoints"
 import useCurrentUser from "../../../use-current-user.js"
@@ -24,7 +23,7 @@ const styles = {}
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenu extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ComponentsAdminLayoutMenu extends ShapeComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.string,
     noAccess: PropTypes.bool.isRequired,

--- a/npm-api-maker/src/super-admin/layout/menu/index.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/index.jsx
@@ -22,8 +22,8 @@ import {WithDefaultStyle} from "../../../utils/default-style"
 const dataSets = {}
 const styles = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenu extends BaseComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.string,

--- a/npm-api-maker/src/super-admin/layout/menu/menu-content.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/menu-content.jsx
@@ -12,7 +12,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import useCanCan from "../../../use-can-can.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
-export default memo(shapeComponent(class ComponentsAdminLayoutMenuContent extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenuContent extends BaseComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.string
   })

--- a/npm-api-maker/src/super-admin/layout/menu/menu-content.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/menu-content.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable new-cap, newline-per-chained-call, sort-imports */
 import React, {useMemo} from "react"
-import BaseComponent from "../../../base-component"
 import {digg} from "diggerize"
 import memo from "set-state-compare/build/memo.js"
 import MenuItem from "./menu-item"
@@ -8,13 +7,13 @@ import models from "../../models.js"
 import Params from "../../../params.js"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import useCanCan from "../../../use-can-can.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenuContent extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ComponentsAdminLayoutMenuContent extends ShapeComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.string
   })

--- a/npm-api-maker/src/super-admin/layout/menu/menu-content.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/menu-content.jsx
@@ -12,8 +12,8 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import useCanCan from "../../../use-can-can.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenuContent extends BaseComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.string

--- a/npm-api-maker/src/super-admin/layout/menu/menu-item.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/menu-item.jsx
@@ -1,11 +1,10 @@
 /* eslint-disable no-return-assign, react/jsx-one-expression-per-line, sort-imports */
-import BaseComponent from "../../../base-component"
 import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import Link from "../../../link"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../../utils/text"
 
 const dataSets = {}
@@ -21,7 +20,7 @@ const dataSets = {}
  * @typedef {object} State
  * @property {boolean} hover
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenuMenuItem extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ComponentsAdminLayoutMenuMenuItem extends ShapeComponent {
   static propTypes = {
     active: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     className: PropTypes.string,

--- a/npm-api-maker/src/super-admin/layout/menu/menu-item.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/menu-item.jsx
@@ -10,7 +10,9 @@ import Text from "../../../utils/text"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ComponentsAdminLayoutMenuMenuItem extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenuMenuItem extends BaseComponent {
   static propTypes = {
     active: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     className: PropTypes.string,

--- a/npm-api-maker/src/super-admin/layout/menu/menu-item.jsx
+++ b/npm-api-maker/src/super-admin/layout/menu/menu-item.jsx
@@ -10,8 +10,17 @@ import Text from "../../../utils/text"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {boolean|string=} active
+ * @property {string=} className
+ * @property {string} icon
+ * @property {any=} label
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} hover
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutMenuMenuItem extends BaseComponent {
   static propTypes = {
     active: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),

--- a/npm-api-maker/src/super-admin/layout/no-access.jsx
+++ b/npm-api-maker/src/super-admin/layout/no-access.jsx
@@ -10,7 +10,9 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ComponentsAdminLayoutNoAccess extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutNoAccess extends BaseComponent {
   render() {
     const currentUser = useCurrentUser()
     const {t} = useI18n({namespace: "js.api_maker.super_admin.layout.no_access"})

--- a/npm-api-maker/src/super-admin/layout/no-access.jsx
+++ b/npm-api-maker/src/super-admin/layout/no-access.jsx
@@ -1,9 +1,8 @@
 /* eslint-disable newline-per-chained-call, no-return-assign, react/jsx-one-expression-per-line, sort-imports */
-import BaseComponent from "../../base-component"
 import memo from "set-state-compare/build/memo.js"
 import React from "react"
 import {View} from "react-native"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 import useCurrentUser from "../../use-current-user.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
@@ -12,7 +11,7 @@ const dataSets = {}
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutNoAccess extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ComponentsAdminLayoutNoAccess extends ShapeComponent {
   render() {
     const currentUser = useCurrentUser()
     const {t} = useI18n({namespace: "js.api_maker.super_admin.layout.no_access"})

--- a/npm-api-maker/src/super-admin/layout/no-access.jsx
+++ b/npm-api-maker/src/super-admin/layout/no-access.jsx
@@ -10,8 +10,8 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ComponentsAdminLayoutNoAccess extends BaseComponent {
   render() {
     const currentUser = useCurrentUser()

--- a/npm-api-maker/src/super-admin/model-class-table.jsx
+++ b/npm-api-maker/src/super-admin/model-class-table.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../base-component"
 import ConfigReader from "./config-reader"
 import {digg} from "diggerize"
 import hasEditConfig from "./has-edit-config.js"
@@ -8,7 +7,7 @@ import memo from "set-state-compare/build/memo.js"
 import Params from "../params.js"
 import PropTypes from "prop-types"
 import React, {useMemo} from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Table from "../table/table"
 import useCurrentUser from "../use-current-user.js"
 
@@ -17,7 +16,7 @@ import useCurrentUser from "../use-current-user.js"
  * @property {Function} modelClass
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminModelClassTable extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminModelClassTable extends ShapeComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired
   }

--- a/npm-api-maker/src/super-admin/model-class-table.jsx
+++ b/npm-api-maker/src/super-admin/model-class-table.jsx
@@ -12,8 +12,11 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Table from "../table/table"
 import useCurrentUser from "../use-current-user.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {Function} modelClass
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminModelClassTable extends BaseComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired

--- a/npm-api-maker/src/super-admin/model-class-table.jsx
+++ b/npm-api-maker/src/super-admin/model-class-table.jsx
@@ -12,7 +12,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Table from "../table/table"
 import useCurrentUser from "../use-current-user.js"
 
-export default memo(shapeComponent(class ApiMakerSuperAdminModelClassTable extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminModelClassTable extends BaseComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired
   }

--- a/npm-api-maker/src/super-admin/show-nav.jsx
+++ b/npm-api-maker/src/super-admin/show-nav.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable implicit-arrow-linebreak, new-cap, react/jsx-max-depth, sort-imports */
-import BaseComponent from "../base-component"
 import Link from "../link"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
 import memo from "set-state-compare/build/memo.js"
 import Params from "../params.js"
 import React, {useMemo} from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import ShowReflectionLink from "./show-reflection-link"
 import Text from "../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
@@ -15,7 +14,7 @@ import {View} from "react-native"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowNav extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminShowNav extends ShapeComponent {
   static propTypes = PropTypesExact({
     model: PropTypes.object.isRequired,
     modelClass: PropTypes.func.isRequired

--- a/npm-api-maker/src/super-admin/show-nav.jsx
+++ b/npm-api-maker/src/super-admin/show-nav.jsx
@@ -13,7 +13,9 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import {View} from "react-native"
 
-export default memo(shapeComponent(class ApiMakerSuperAdminShowNav extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowNav extends BaseComponent {
   static propTypes = PropTypesExact({
     model: PropTypes.object.isRequired,
     modelClass: PropTypes.func.isRequired

--- a/npm-api-maker/src/super-admin/show-nav.jsx
+++ b/npm-api-maker/src/super-admin/show-nav.jsx
@@ -13,8 +13,8 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import {View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowNav extends BaseComponent {
   static propTypes = PropTypesExact({
     model: PropTypes.object.isRequired,

--- a/npm-api-maker/src/super-admin/show-page/belongs-to-attribute-row.jsx
+++ b/npm-api-maker/src/super-admin/show-page/belongs-to-attribute-row.jsx
@@ -9,7 +9,9 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 
-export default memo(shapeComponent(class ApiMakerSuperAdminShowPageBelongsToAttributeRow extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowPageBelongsToAttributeRow extends BaseComponent {
   render() {
     const {model, modelClass, reflection} = this.props
     const reflectionMethodName = inflection.camelize(reflection.name(), true)

--- a/npm-api-maker/src/super-admin/show-page/belongs-to-attribute-row.jsx
+++ b/npm-api-maker/src/super-admin/show-page/belongs-to-attribute-row.jsx
@@ -1,17 +1,22 @@
 /* eslint-disable sort-imports */
 import AttributeRow from "../../bootstrap/attribute-row"
-import BaseComponent from "../../base-component"
 import * as inflection from "inflection"
 import Link from "../../link"
 import memo from "set-state-compare/build/memo.js"
 import Params from "../../params.js"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 
-/** @typedef {Record<string, never>} Props */
+/**
+ * @typedef {object} Props
+ * @property {any} model
+ * @property {any} modelClass
+ * @property {any} reflection
+ */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowPageBelongsToAttributeRow extends BaseComponent {
+/** @augments {ShapeComponent<Props, State>} */
+class ApiMakerSuperAdminShowPageBelongsToAttributeRow extends ShapeComponent {
   render() {
     const {model, modelClass, reflection} = this.props
     const reflectionMethodName = inflection.camelize(reflection.name(), true)
@@ -30,4 +35,6 @@ export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} *
       </AttributeRow>
     )
   }
-}))
+}
+
+export default memo(shapeComponent(ApiMakerSuperAdminShowPageBelongsToAttributeRow))

--- a/npm-api-maker/src/super-admin/show-page/belongs-to-attribute-row.jsx
+++ b/npm-api-maker/src/super-admin/show-page/belongs-to-attribute-row.jsx
@@ -9,8 +9,8 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowPageBelongsToAttributeRow extends BaseComponent {
   render() {
     const {model, modelClass, reflection} = this.props

--- a/npm-api-maker/src/super-admin/show-page/index.jsx
+++ b/npm-api-maker/src/super-admin/show-page/index.jsx
@@ -31,8 +31,11 @@ const AttributePresenter = memo(({attribute, model, modelArgs}) => {
   )
 })
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {Function} modelClass
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowPage extends BaseComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired

--- a/npm-api-maker/src/super-admin/show-page/index.jsx
+++ b/npm-api-maker/src/super-admin/show-page/index.jsx
@@ -1,14 +1,13 @@
 /* eslint-disable complexity, implicit-arrow-linebreak, max-len, newline-per-chained-call, react/jsx-sort-props, sort-imports */
 import React, {useMemo} from "react"
 import AttributeRow from "../../bootstrap/attribute-row"
-import BaseComponent from "../../base-component"
 import BelongsToAttributeRow from "./belongs-to-attribute-row"
 import ConfigReader from "../config-reader"
 import {digg} from "diggerize"
 import memo from "set-state-compare/build/memo.js"
 import * as inflection from "inflection"
 import PropTypes from "prop-types"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import ShowNav from "../show-nav"
 import useModel from "../../use-model.js"
 import {View} from "react-native"
@@ -36,7 +35,7 @@ const AttributePresenter = memo(({attribute, model, modelArgs}) => {
  * @property {Function} modelClass
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowPage extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminShowPage extends ShapeComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired
   }

--- a/npm-api-maker/src/super-admin/show-page/index.jsx
+++ b/npm-api-maker/src/super-admin/show-page/index.jsx
@@ -31,7 +31,9 @@ const AttributePresenter = memo(({attribute, model, modelArgs}) => {
   )
 })
 
-export default memo(shapeComponent(class ApiMakerSuperAdminShowPage extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowPage extends BaseComponent {
   static propTypes = {
     modelClass: PropTypes.func.isRequired
   }

--- a/npm-api-maker/src/super-admin/show-reflection-actions.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-actions.jsx
@@ -11,8 +11,13 @@ import propTypesExact from "prop-types-exact"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import useCanCan from "../use-can-can.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} model
+ * @property {Function=} modelClass
+ * @property {string=} reflectionName
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SuperAdminShowReflectionActions extends BaseComponent {
   static propTypes = propTypesExact({
     model: PropTypes.object,

--- a/npm-api-maker/src/super-admin/show-reflection-actions.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-actions.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-no-literals, react/jsx-no-useless-fragment, sort-imports */
-import BaseComponent from "../base-component"
 import {digg} from "diggerize"
 import * as inflection from "inflection"
 import Link from "../link"
@@ -8,7 +7,7 @@ import React, {useMemo} from "react"
 import Params from "../params.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import useCanCan from "../use-can-can.js"
 
 /**
@@ -18,7 +17,7 @@ import useCanCan from "../use-can-can.js"
  * @property {string=} reflectionName
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SuperAdminShowReflectionActions extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class SuperAdminShowReflectionActions extends ShapeComponent {
   static propTypes = propTypesExact({
     model: PropTypes.object,
     modelClass: PropTypes.func,

--- a/npm-api-maker/src/super-admin/show-reflection-actions.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-actions.jsx
@@ -11,7 +11,9 @@ import propTypesExact from "prop-types-exact"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import useCanCan from "../use-can-can.js"
 
-export default memo(shapeComponent(class SuperAdminShowReflectionActions extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SuperAdminShowReflectionActions extends BaseComponent {
   static propTypes = propTypesExact({
     model: PropTypes.object,
     modelClass: PropTypes.func,

--- a/npm-api-maker/src/super-admin/show-reflection-link.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-link.jsx
@@ -1,11 +1,10 @@
 /* eslint-disable react/jsx-curly-brace-presence, sort-imports */
-import BaseComponent from "../base-component"
 import {digg} from "diggerize"
 import Link from "../link"
 import memo from "set-state-compare/build/memo.js"
 import Params from "../params.js"
 import React, {useMemo} from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../utils/text"
 
 /** @typedef {Record<string, never>} Props */
@@ -13,7 +12,7 @@ import Text from "../utils/text"
  * @typedef {object} State
  * @property {any} count
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionLink extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionLink extends ShapeComponent {
   state = {
     count: undefined
   }

--- a/npm-api-maker/src/super-admin/show-reflection-link.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-link.jsx
@@ -8,7 +8,9 @@ import React, {useMemo} from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../utils/text"
 
-export default memo(shapeComponent(class ApiMakerSuperAdminShowReflectionLink extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionLink extends BaseComponent {
   state = {
     count: undefined
   }

--- a/npm-api-maker/src/super-admin/show-reflection-link.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-link.jsx
@@ -8,8 +8,11 @@ import React, {useMemo} from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../utils/text"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/**
+ * @typedef {object} State
+ * @property {any} count
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionLink extends BaseComponent {
   state = {
     count: undefined

--- a/npm-api-maker/src/super-admin/show-reflection-page.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-page.jsx
@@ -12,8 +12,12 @@ import useModel from "../use-model.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import {View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {Function} modelClass
+ * @property {string} modelId
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionPage extends BaseComponent {
   static propTypes = propTypesExact({
     modelClass: PropTypes.func.isRequired,

--- a/npm-api-maker/src/super-admin/show-reflection-page.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-page.jsx
@@ -12,7 +12,9 @@ import useModel from "../use-model.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import {View} from "react-native"
 
-export default memo(shapeComponent(class ApiMakerSuperAdminShowReflectionPage extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionPage extends BaseComponent {
   static propTypes = propTypesExact({
     modelClass: PropTypes.func.isRequired,
     modelId: PropTypes.string.isRequired

--- a/npm-api-maker/src/super-admin/show-reflection-page.jsx
+++ b/npm-api-maker/src/super-admin/show-reflection-page.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../base-component"
 import {digg} from "diggerize"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import memo from "set-state-compare/build/memo.js"
 import ModelClassTable from "./model-class-table"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import ShowNav from "./show-nav"
 import useModel from "../use-model.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
@@ -18,7 +17,7 @@ import {View} from "react-native"
  * @property {string} modelId
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionPage extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerSuperAdminShowReflectionPage extends ShapeComponent {
   static propTypes = propTypesExact({
     modelClass: PropTypes.func.isRequired,
     modelId: PropTypes.string.isRequired

--- a/npm-api-maker/src/table/components/column.jsx
+++ b/npm-api-maker/src/table/components/column.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../../base-component"
 import memo from "set-state-compare/build/memo.js"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Animated} from "react-native"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableColumn extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class SharedTableColumn extends ShapeComponent {
   render() {
     const {dataSet, ...restProps} = this.props
     const actualDataSet = Object.assign( // eslint-disable-line prefer-object-spread

--- a/npm-api-maker/src/table/components/column.jsx
+++ b/npm-api-maker/src/table/components/column.jsx
@@ -5,8 +5,8 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Animated} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableColumn extends BaseComponent {
   render() {
     const {dataSet, ...restProps} = this.props

--- a/npm-api-maker/src/table/components/column.jsx
+++ b/npm-api-maker/src/table/components/column.jsx
@@ -5,7 +5,9 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Animated} from "react-native"
 
-export default memo(shapeComponent(class SharedTableColumn extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableColumn extends BaseComponent {
   render() {
     const {dataSet, ...restProps} = this.props
     const actualDataSet = Object.assign( // eslint-disable-line prefer-object-spread

--- a/npm-api-maker/src/table/components/flat-list.jsx
+++ b/npm-api-maker/src/table/components/flat-list.jsx
@@ -5,7 +5,9 @@ import memo from "set-state-compare/build/memo.js"
 import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 
-export default memo(shapeComponent(class SharedTagble extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTagble extends BaseComponent {
   render() {
     const {style, ...restProps} = this.props
     const actualStyle = Object.assign( // eslint-disable-line prefer-object-spread

--- a/npm-api-maker/src/table/components/flat-list.jsx
+++ b/npm-api-maker/src/table/components/flat-list.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../../base-component"
 import {FlatList} from "react-native"
 import memo from "set-state-compare/build/memo.js"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTagble extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class SharedTagble extends ShapeComponent {
   render() {
     const {style, ...restProps} = this.props
     const actualStyle = Object.assign( // eslint-disable-line prefer-object-spread

--- a/npm-api-maker/src/table/components/flat-list.jsx
+++ b/npm-api-maker/src/table/components/flat-list.jsx
@@ -5,8 +5,8 @@ import memo from "set-state-compare/build/memo.js"
 import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTagble extends BaseComponent {
   render() {
     const {style, ...restProps} = this.props

--- a/npm-api-maker/src/table/components/header.jsx
+++ b/npm-api-maker/src/table/components/header.jsx
@@ -6,8 +6,8 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Animated} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableHeader extends BaseComponent {
   render() {
     const {dataSet, ...restProps} = this.props

--- a/npm-api-maker/src/table/components/header.jsx
+++ b/npm-api-maker/src/table/components/header.jsx
@@ -1,14 +1,13 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../../base-component"
 import classNames from "classnames" // eslint-disable-line import/no-unresolved
 import memo from "set-state-compare/build/memo.js"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Animated} from "react-native"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableHeader extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class SharedTableHeader extends ShapeComponent {
   render() {
     const {dataSet, ...restProps} = this.props
     const {component, ...restDataSet} = dataSet || {}

--- a/npm-api-maker/src/table/components/header.jsx
+++ b/npm-api-maker/src/table/components/header.jsx
@@ -6,7 +6,9 @@ import React from "react"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Animated} from "react-native"
 
-export default memo(shapeComponent(class SharedTableHeader extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableHeader extends BaseComponent {
   render() {
     const {dataSet, ...restProps} = this.props
     const {component, ...restDataSet} = dataSet || {}

--- a/npm-api-maker/src/table/components/row.jsx
+++ b/npm-api-maker/src/table/components/row.jsx
@@ -1,14 +1,13 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../../base-component"
 import memo from "set-state-compare/build/memo.js"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useBreakpoint} from "responsive-breakpoints"
 import {View} from "react-native"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableRow extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class SharedTableRow extends ShapeComponent {
   render() {
     const {style, ...restProps} = this.props
     const {name: breakpoint, smDown} = useBreakpoint()

--- a/npm-api-maker/src/table/components/row.jsx
+++ b/npm-api-maker/src/table/components/row.jsx
@@ -6,7 +6,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useBreakpoint} from "responsive-breakpoints"
 import {View} from "react-native"
 
-export default memo(shapeComponent(class SharedTableRow extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableRow extends BaseComponent {
   render() {
     const {style, ...restProps} = this.props
     const {name: breakpoint, smDown} = useBreakpoint()

--- a/npm-api-maker/src/table/components/row.jsx
+++ b/npm-api-maker/src/table/components/row.jsx
@@ -6,8 +6,8 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useBreakpoint} from "responsive-breakpoints"
 import {View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class SharedTableRow extends BaseComponent {
   render() {
     const {style, ...restProps} = this.props

--- a/npm-api-maker/src/table/filters/attribute-element.jsx
+++ b/npm-api-maker/src/table/filters/attribute-element.jsx
@@ -11,7 +11,9 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class AttributeElement extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class AttributeElement extends BaseComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.bool.isRequired,
     attribute: PropTypes.object.isRequired,

--- a/npm-api-maker/src/table/filters/attribute-element.jsx
+++ b/npm-api-maker/src/table/filters/attribute-element.jsx
@@ -1,19 +1,18 @@
 /* eslint-disable new-cap, no-return-assign, sort-imports */
-import BaseComponent from "../../base-component"
 import {digg} from "diggerize"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
 import memo from "set-state-compare/build/memo.js"
 import {Pressable} from "react-native"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 
 const dataSets = {}
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class AttributeElement extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class AttributeElement extends ShapeComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.bool.isRequired,
     attribute: PropTypes.object.isRequired,

--- a/npm-api-maker/src/table/filters/attribute-element.jsx
+++ b/npm-api-maker/src/table/filters/attribute-element.jsx
@@ -11,8 +11,8 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class AttributeElement extends BaseComponent {
   static propTypes = PropTypesExact({
     active: PropTypes.bool.isRequired,

--- a/npm-api-maker/src/table/filters/filter-form.jsx
+++ b/npm-api-maker/src/table/filters/filter-form.jsx
@@ -28,8 +28,22 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
 const styles = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/**
+ * @typedef {object} State
+ * @property {object} actualCurrentModelClass
+ * @property {any} associations
+ * @property {any} attribute
+ * @property {number} loading
+ * @property {any} modelClassName
+ * @property {any[]} path
+ * @property {any} predicate
+ * @property {any} predicates
+ * @property {any} ransackableAttributes
+ * @property {any} ransackableScopes
+ * @property {any} scope
+ * @property {any} value
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersFilterForm extends BaseComponent {
   static propTypes = PropTypesExact({
     filter: PropTypes.object,

--- a/npm-api-maker/src/table/filters/filter-form.jsx
+++ b/npm-api-maker/src/table/filters/filter-form.jsx
@@ -5,7 +5,6 @@
 import React, {useMemo, useRef} from "react"
 import {ActivityIndicator, View} from "react-native"
 import AttributeElement from "./attribute-element"
-import BaseComponent from "../../base-component"
 import Button from "../../utils/button"
 import Card from "../../utils/card"
 import {digg, digs} from "diggerize"
@@ -21,7 +20,7 @@ import ReflectionElement from "./reflection-element"
 import ScopeElement from "./scope-element"
 import Select from "../../inputs/select"
 import Services from "../../services.js"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 import {useBreakpoint} from "responsive-breakpoints"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
@@ -44,7 +43,7 @@ const styles = {}
  * @property {any} scope
  * @property {any} value
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersFilterForm extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableFiltersFilterForm extends ShapeComponent {
   static propTypes = PropTypesExact({
     filter: PropTypes.object,
     modelClass: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/filters/filter-form.jsx
+++ b/npm-api-maker/src/table/filters/filter-form.jsx
@@ -28,7 +28,9 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
 const styles = {}
 
-export default memo(shapeComponent(class ApiMakerTableFiltersFilterForm extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersFilterForm extends BaseComponent {
   static propTypes = PropTypesExact({
     filter: PropTypes.object,
     modelClass: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/filters/filter.jsx
+++ b/npm-api-maker/src/table/filters/filter.jsx
@@ -11,8 +11,8 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFilter extends BaseComponent {
   static defaultProps = {
     a: null,

--- a/npm-api-maker/src/table/filters/filter.jsx
+++ b/npm-api-maker/src/table/filters/filter.jsx
@@ -1,19 +1,18 @@
 /* eslint-disable max-len, new-cap, no-return-assign, react/jsx-one-expression-per-line, sort-imports */
 import {Pressable, View} from "react-native"
-import BaseComponent from "../../base-component"
 import Icon from "../../utils/icon"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
 import memo from "set-state-compare/build/memo.js"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 
 const dataSets = {}
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFilter extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableFilter extends ShapeComponent {
   static defaultProps = {
     a: null,
     pre: null

--- a/npm-api-maker/src/table/filters/filter.jsx
+++ b/npm-api-maker/src/table/filters/filter.jsx
@@ -11,7 +11,9 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ApiMakerTableFilter extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFilter extends BaseComponent {
   static defaultProps = {
     a: null,
     pre: null

--- a/npm-api-maker/src/table/filters/index.jsx
+++ b/npm-api-maker/src/table/filters/index.jsx
@@ -17,7 +17,9 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import {View} from "react-native"
 
-export default memo(shapeComponent(class ApiMakerTableFilters extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFilters extends BaseComponent {
   static propTypes = {
     currentUser: PropTypes.object,
     modelClass: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/filters/index.jsx
+++ b/npm-api-maker/src/table/filters/index.jsx
@@ -17,8 +17,19 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 import {View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} currentUser
+ * @property {Function} modelClass
+ * @property {string} queryName
+ * @property {string} querySName
+ */
+/**
+ * @typedef {object} State
+ * @property {any} filter
+ * @property {any} showLoadSearchModal
+ * @property {boolean} showSaveSearchModal
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFilters extends BaseComponent {
   static propTypes = {
     currentUser: PropTypes.object,

--- a/npm-api-maker/src/table/filters/index.jsx
+++ b/npm-api-maker/src/table/filters/index.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable implicit-arrow-linebreak, import/no-unresolved, max-len, react/button-has-type, react/jsx-sort-props, react/no-array-index-key, sort-imports */
-import BaseComponent from "../../base-component"
 import {digg, digs} from "diggerize"
 import Filter from "./filter"
 import FilterForm from "./filter-form"
@@ -11,7 +10,7 @@ import PropTypes from "prop-types"
 // @ts-expect-error Runtime-resolved module
 import {TableSearch} from "models.js"
 import memo from "set-state-compare/build/memo.js"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import React from "react"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
@@ -30,7 +29,7 @@ import {View} from "react-native"
  * @property {any} showLoadSearchModal
  * @property {boolean} showSaveSearchModal
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFilters extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableFilters extends ShapeComponent {
   static propTypes = {
     currentUser: PropTypes.object,
     modelClass: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/filters/load-search-modal.jsx
+++ b/npm-api-maker/src/table/filters/load-search-modal.jsx
@@ -2,11 +2,10 @@
 /* eslint-disable react/jsx-max-depth, react/jsx-no-literals, sort-imports */
 import React, {useMemo} from "react"
 import {Pressable, View} from "react-native"
-import BaseComponent from "../../base-component"
 import classNames from "classnames"
 import {digg} from "diggerize"
 import memo from "set-state-compare/build/memo.js"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Params from "../../params.js"
 // @ts-expect-error Runtime-resolved module
 import {TableSearch} from "models.js"
@@ -22,7 +21,7 @@ import apiMakerConfig from "../../config.js"
  * @property {TableSearch} search
  */
 /** @typedef {Record<string, never>} SearchLinkState */
-const SearchLink = memo(shapeComponent(/** @augments {BaseComponent<SearchLinkProps, SearchLinkState>} */ class SearchLink extends BaseComponent {
+const SearchLink = memo(shapeComponent(/** @augments {ShapeComponent<SearchLinkProps, SearchLinkState>} */ class SearchLink extends ShapeComponent {
   render() {
     const {search} = this.props
 
@@ -111,7 +110,7 @@ const SearchLink = memo(shapeComponent(/** @augments {BaseComponent<SearchLinkPr
  * @property {any} editSearch
  * @property {TableSearch[]|undefined} searches
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersLoadSearchModal extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableFiltersLoadSearchModal extends ShapeComponent {
   state = {
     editSearch: undefined,
     searches: undefined

--- a/npm-api-maker/src/table/filters/load-search-modal.jsx
+++ b/npm-api-maker/src/table/filters/load-search-modal.jsx
@@ -14,7 +14,9 @@ import Text from "../../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import apiMakerConfig from "../../config.js"
 
-const SearchLink = memo(shapeComponent(class SearchLink extends BaseComponent {
+/** @typedef {object} SearchLinkProps */
+/** @typedef {object} SearchLinkState */
+const SearchLink = memo(shapeComponent(/** @augments {BaseComponent<SearchLinkProps, SearchLinkState>} */ class SearchLink extends BaseComponent {
   render() {
     const {search} = this.props
 
@@ -90,7 +92,9 @@ const SearchLink = memo(shapeComponent(class SearchLink extends BaseComponent {
   onSearchClicked = () => this.props.onClick({search: this.props.search})
 }))
 
-export default memo(shapeComponent(class ApiMakerTableFiltersLoadSearchModal extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersLoadSearchModal extends BaseComponent {
   state = {
     editSearch: undefined,
     searches: undefined

--- a/npm-api-maker/src/table/filters/load-search-modal.jsx
+++ b/npm-api-maker/src/table/filters/load-search-modal.jsx
@@ -14,8 +14,14 @@ import Text from "../../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import apiMakerConfig from "../../config.js"
 
-/** @typedef {object} SearchLinkProps */
-/** @typedef {object} SearchLinkState */
+/**
+ * @typedef {object} SearchLinkProps
+ * @property {Function} onClick
+ * @property {Function} onDeleted
+ * @property {Function} onEditPressed
+ * @property {TableSearch} search
+ */
+/** @typedef {Record<string, never>} SearchLinkState */
 const SearchLink = memo(shapeComponent(/** @augments {BaseComponent<SearchLinkProps, SearchLinkState>} */ class SearchLink extends BaseComponent {
   render() {
     const {search} = this.props
@@ -92,8 +98,19 @@ const SearchLink = memo(shapeComponent(/** @augments {BaseComponent<SearchLinkPr
   onSearchClicked = () => this.props.onClick({search: this.props.search})
 }))
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} className
+ * @property {object} currentUser
+ * @property {Function} onEditSearchPressed
+ * @property {Function} onRequestClose
+ * @property {string} querySearchName
+ */
+/**
+ * @typedef {object} State
+ * @property {any} editSearch
+ * @property {TableSearch[]|undefined} searches
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersLoadSearchModal extends BaseComponent {
   state = {
     editSearch: undefined,

--- a/npm-api-maker/src/table/filters/reflection-element.jsx
+++ b/npm-api-maker/src/table/filters/reflection-element.jsx
@@ -10,8 +10,8 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ReflectionElement extends BaseComponent {
   static propTypes = PropTypesExact({
     modelClassName: PropTypes.string.isRequired,

--- a/npm-api-maker/src/table/filters/reflection-element.jsx
+++ b/npm-api-maker/src/table/filters/reflection-element.jsx
@@ -10,7 +10,9 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ReflectionElement extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ReflectionElement extends BaseComponent {
   static propTypes = PropTypesExact({
     modelClassName: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/filters/reflection-element.jsx
+++ b/npm-api-maker/src/table/filters/reflection-element.jsx
@@ -1,18 +1,17 @@
 /* eslint-disable new-cap, no-return-assign, sort-imports */
-import BaseComponent from "../../base-component"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
 import memo from "set-state-compare/build/memo.js"
 import {Pressable} from "react-native"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 
 const dataSets = {}
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ReflectionElement extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ReflectionElement extends ShapeComponent {
   static propTypes = PropTypesExact({
     modelClassName: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/filters/save-search-modal.jsx
+++ b/npm-api-maker/src/table/filters/save-search-modal.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/button-has-type, sort-imports */
-import BaseComponent from "../../base-component"
 import Checkbox from "../../bootstrap/checkbox"
 import {digg} from "diggerize"
 import {FlashNotifications} from "flash-notifications"
@@ -7,7 +6,7 @@ import {Form} from "../../form"
 import Input from "../../bootstrap/input"
 import modelClassRequire from "../../model-class-require.js"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import memo from "set-state-compare/build/memo.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import apiMakerConfig from "../../config.js"
@@ -19,7 +18,7 @@ const TableSearch = modelClassRequire("TableSearch")
  * @typedef {object} State
  * @property {any} form
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersSaveSearchModal extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableFiltersSaveSearchModal extends ShapeComponent {
   state = {
     form: null
   }

--- a/npm-api-maker/src/table/filters/save-search-modal.jsx
+++ b/npm-api-maker/src/table/filters/save-search-modal.jsx
@@ -14,7 +14,9 @@ import apiMakerConfig from "../../config.js"
 
 const TableSearch = modelClassRequire("TableSearch")
 
-export default memo(shapeComponent(class ApiMakerTableFiltersSaveSearchModal extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersSaveSearchModal extends BaseComponent {
   state = {
     form: null
   }

--- a/npm-api-maker/src/table/filters/save-search-modal.jsx
+++ b/npm-api-maker/src/table/filters/save-search-modal.jsx
@@ -14,8 +14,11 @@ import apiMakerConfig from "../../config.js"
 
 const TableSearch = modelClassRequire("TableSearch")
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/**
+ * @typedef {object} State
+ * @property {any} form
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableFiltersSaveSearchModal extends BaseComponent {
   state = {
     form: null

--- a/npm-api-maker/src/table/filters/scope-element.jsx
+++ b/npm-api-maker/src/table/filters/scope-element.jsx
@@ -21,7 +21,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   static propTypes = {
-    active: PropTypes.bool.isRequired,
+    active: PropTypes.bool,
     onScopeClicked: PropTypes.func.isRequired,
     scope: PropTypes.string.isRequired
   }

--- a/npm-api-maker/src/table/filters/scope-element.jsx
+++ b/npm-api-maker/src/table/filters/scope-element.jsx
@@ -9,7 +9,9 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ScopeElement extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ScopeElement extends BaseComponent {
   static defaultProps = {
     active: false
   }

--- a/npm-api-maker/src/table/filters/scope-element.jsx
+++ b/npm-api-maker/src/table/filters/scope-element.jsx
@@ -9,8 +9,13 @@ import Text from "../../utils/text"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {boolean=} active
+ * @property {Function} onScopeClicked
+ * @property {string} scope
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ScopeElement extends BaseComponent {
   static defaultProps = {
     active: false

--- a/npm-api-maker/src/table/filters/scope-element.jsx
+++ b/npm-api-maker/src/table/filters/scope-element.jsx
@@ -1,10 +1,9 @@
 /* eslint-disable no-return-assign, sort-imports */
-import BaseComponent from "../../base-component"
 import PropTypes from "prop-types"
 import memo from "set-state-compare/build/memo.js"
 import {Pressable} from "react-native"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 
 const dataSets = {}
@@ -16,7 +15,7 @@ const dataSets = {}
  * @property {string} scope
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ScopeElement extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ScopeElement extends ShapeComponent {
   static defaultProps = {
     active: false
   }

--- a/npm-api-maker/src/table/header-column-content.jsx
+++ b/npm-api-maker/src/table/header-column-content.jsx
@@ -10,8 +10,14 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import SortLink from "../bootstrap/sort-link"
 import Text from "../utils/text"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object} column
+ * @property {object=} sortLinkProps
+ * @property {object} table
+ * @property {object} tableSettingColumn
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends BaseComponent {
   static propTypes = propTypesExact({
     column: PropTypes.object.isRequired,

--- a/npm-api-maker/src/table/header-column-content.jsx
+++ b/npm-api-maker/src/table/header-column-content.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable sort-imports */
-import BaseComponent from "../base-component"
 import {digs} from "diggerize"
 import memo from "set-state-compare/build/memo.js"
 import {View} from "react-native"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import SortLink from "../bootstrap/sort-link"
 import Text from "../utils/text"
 
@@ -18,7 +17,7 @@ import Text from "../utils/text"
  * @property {object} tableSettingColumn
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends ShapeComponent {
   static propTypes = propTypesExact({
     column: PropTypes.object.isRequired,
     sortLinkProps: PropTypes.object,

--- a/npm-api-maker/src/table/header-column-content.jsx
+++ b/npm-api-maker/src/table/header-column-content.jsx
@@ -10,7 +10,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import SortLink from "../bootstrap/sort-link"
 import Text from "../utils/text"
 
-export default memo(shapeComponent(class ApiMakerTableHeaderColumn extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends BaseComponent {
   static propTypes = propTypesExact({
     column: PropTypes.object.isRequired,
     sortLinkProps: PropTypes.object,

--- a/npm-api-maker/src/table/header-column.jsx
+++ b/npm-api-maker/src/table/header-column.jsx
@@ -15,7 +15,9 @@ import Widths from "./widths"
 
 const dataSets = {}
 
-export default memo(shapeComponent(class ApiMakerTableHeaderColumn extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends BaseComponent {
   static propTypes = propTypesExact({
     active: PropTypes.bool.isRequired,
     animatedWidth: PropTypes.instanceOf(Animated.Value).isRequired,

--- a/npm-api-maker/src/table/header-column.jsx
+++ b/npm-api-maker/src/table/header-column.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-unresolved, no-return-assign, sort-imports */
 import React, {useMemo} from "react"
-import BaseComponent from "../base-component"
 import classNames from "classnames"
 import Header from "./components/header"
 import HeaderColumnContent from "./header-column-content"
@@ -9,7 +8,7 @@ import memo from "set-state-compare/build/memo.js"
 import {Animated, PanResponder} from "react-native"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useBreakpoint} from "responsive-breakpoints"
 import Widths from "./widths"
 
@@ -31,7 +30,7 @@ const dataSets = {}
  * @typedef {object} State
  * @property {boolean} resizing
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends ShapeComponent {
   static propTypes = propTypesExact({
     active: PropTypes.bool.isRequired,
     animatedWidth: PropTypes.instanceOf(Animated.Value).isRequired,

--- a/npm-api-maker/src/table/header-column.jsx
+++ b/npm-api-maker/src/table/header-column.jsx
@@ -15,8 +15,22 @@ import Widths from "./widths"
 
 const dataSets = {}
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {boolean} active
+ * @property {any} animatedWidth
+ * @property {any} animatedZIndex
+ * @property {object} column
+ * @property {boolean} resizing
+ * @property {object} table
+ * @property {object} tableSettingColumn
+ * @property {object} touchProps
+ * @property {Widths} widths
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} resizing
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderColumn extends BaseComponent {
   static propTypes = propTypesExact({
     active: PropTypes.bool.isRequired,

--- a/npm-api-maker/src/table/header-select.jsx
+++ b/npm-api-maker/src/table/header-select.jsx
@@ -13,8 +13,16 @@ import Text from "../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useSorting from "./use-sorting.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any[]} preparedColumns
+ * @property {Collection} query
+ * @property {object=} table
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} modalOpen
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderSelect extends BaseComponent {
   static propTypes = propTypesExact({
     preparedColumns: PropTypes.array.isRequired,

--- a/npm-api-maker/src/table/header-select.jsx
+++ b/npm-api-maker/src/table/header-select.jsx
@@ -13,7 +13,9 @@ import Text from "../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useSorting from "./use-sorting.js"
 
-export default memo(shapeComponent(class ApiMakerTableHeaderSelect extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderSelect extends BaseComponent {
   static propTypes = propTypesExact({
     preparedColumns: PropTypes.array.isRequired,
     query: PropTypes.instanceOf(Collection).isRequired,

--- a/npm-api-maker/src/table/header-select.jsx
+++ b/npm-api-maker/src/table/header-select.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable implicit-arrow-linebreak, react/jsx-sort-props, sort-imports */
 import {Pressable, View} from "react-native"
-import BaseComponent from "../base-component"
 import Collection from "../collection.js"
 import HeaderColumnContent from "./header-column-content"
 import memo from "set-state-compare/build/memo.js"
@@ -8,7 +7,7 @@ import Modal from "../utils/modal"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import React from "react"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import useSorting from "./use-sorting.js"
@@ -23,7 +22,7 @@ import useSorting from "./use-sorting.js"
  * @typedef {object} State
  * @property {boolean} modalOpen
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableHeaderSelect extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableHeaderSelect extends ShapeComponent {
   static propTypes = propTypesExact({
     preparedColumns: PropTypes.array.isRequired,
     query: PropTypes.instanceOf(Collection).isRequired,

--- a/npm-api-maker/src/table/model-column.jsx
+++ b/npm-api-maker/src/table/model-column.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable implicit-arrow-linebreak, import/no-unresolved, indent, sort-imports */
 import {Animated, View} from "react-native"
 import React, {useMemo} from "react"
-import BaseComponent from "../base-component"
 import classNames from "classnames"
 import Column from "./components/column"
 import ColumnContent from "./column-content"
@@ -10,7 +9,7 @@ import {EventEmitter} from "eventemitter3"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import memo from "set-state-compare/build/memo.js"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../utils/text"
 import {useBreakpoint} from "responsive-breakpoints"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
@@ -29,7 +28,7 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
  * @property {object} tableSettingColumn
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableModelColumn extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableModelColumn extends ShapeComponent {
   static propTypes = propTypesExact({
     animatedPosition: PropTypes.instanceOf(Animated.ValueXY).isRequired,
     animatedWidth: PropTypes.instanceOf(Animated.Value).isRequired,

--- a/npm-api-maker/src/table/model-column.jsx
+++ b/npm-api-maker/src/table/model-column.jsx
@@ -15,7 +15,9 @@ import Text from "../utils/text"
 import {useBreakpoint} from "responsive-breakpoints"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
-export default memo(shapeComponent(class ApiMakerTableModelColumn extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableModelColumn extends BaseComponent {
   static propTypes = propTypesExact({
     animatedPosition: PropTypes.instanceOf(Animated.ValueXY).isRequired,
     animatedWidth: PropTypes.instanceOf(Animated.Value).isRequired,

--- a/npm-api-maker/src/table/model-column.jsx
+++ b/npm-api-maker/src/table/model-column.jsx
@@ -15,8 +15,20 @@ import Text from "../utils/text"
 import {useBreakpoint} from "responsive-breakpoints"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any} animatedPosition
+ * @property {any} animatedWidth
+ * @property {any} animatedZIndex
+ * @property {object} column
+ * @property {number} columnIndex
+ * @property {boolean} even
+ * @property {EventEmitter} events
+ * @property {object} model
+ * @property {object} table
+ * @property {object} tableSettingColumn
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableModelColumn extends BaseComponent {
   static propTypes = propTypesExact({
     animatedPosition: PropTypes.instanceOf(Animated.ValueXY).isRequired,

--- a/npm-api-maker/src/table/model-row.jsx
+++ b/npm-api-maker/src/table/model-row.jsx
@@ -19,7 +19,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import WorkerPluginsCheckbox from "./worker-plugins-checkbox"
 
-export default memo(shapeComponent(class ApiMakerBootStrapLiveTableModelRow extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootStrapLiveTableModelRow extends BaseComponent {
   static propTypes = propTypesExact({
     cacheKey: PropTypes.string.isRequired,
     columns: PropTypes.array,

--- a/npm-api-maker/src/table/model-row.jsx
+++ b/npm-api-maker/src/table/model-row.jsx
@@ -19,8 +19,18 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import WorkerPluginsCheckbox from "./worker-plugins-checkbox"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string} cacheKey
+ * @property {any[]=} columns
+ * @property {object} columnWidths
+ * @property {EventEmitter} events
+ * @property {number} index
+ * @property {object} model
+ * @property {object} table
+ * @property {string} tableSettingFullCacheKey
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootStrapLiveTableModelRow extends BaseComponent {
   static propTypes = propTypesExact({
     cacheKey: PropTypes.string.isRequired,

--- a/npm-api-maker/src/table/model-row.jsx
+++ b/npm-api-maker/src/table/model-row.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable implicit-arrow-linebreak, max-len, react/jsx-sort-props, sort-imports */
 import {Pressable} from "react-native"
-import BaseComponent from "../base-component"
 import Column from "./components/column"
 import columnIdentifier from "./column-identifier.js"
 import {EventEmitter} from "eventemitter3"
@@ -15,7 +14,7 @@ import propTypesExact from "prop-types-exact"
 import React from "react"
 import Row from "./components/row"
 import memo from "set-state-compare/build/memo.js"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 import WorkerPluginsCheckbox from "./worker-plugins-checkbox"
 
@@ -31,7 +30,7 @@ import WorkerPluginsCheckbox from "./worker-plugins-checkbox"
  * @property {string} tableSettingFullCacheKey
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerBootStrapLiveTableModelRow extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerBootStrapLiveTableModelRow extends ShapeComponent {
   static propTypes = propTypesExact({
     cacheKey: PropTypes.string.isRequired,
     columns: PropTypes.array,

--- a/npm-api-maker/src/table/settings/column-row.jsx
+++ b/npm-api-maker/src/table/settings/column-row.jsx
@@ -1,11 +1,10 @@
 /* eslint-disable max-len, sort-imports */
 import React, {useEffect, useRef} from "react"
-import BaseComponent from "../../base-component"
 import columnIdentifier from "../column-identifier.js"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 import {View} from "react-native"
 
@@ -16,7 +15,7 @@ import {View} from "react-native"
  * @property {object} tableSettingColumn
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ColumnRow extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ColumnRow extends ShapeComponent {
   static propTypes = propTypesExact({
     column: PropTypes.object.isRequired,
     table: PropTypes.object.isRequired,

--- a/npm-api-maker/src/table/settings/column-row.jsx
+++ b/npm-api-maker/src/table/settings/column-row.jsx
@@ -9,7 +9,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 import {View} from "react-native"
 
-export default memo(shapeComponent(class ColumnRow extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ColumnRow extends BaseComponent {
   static propTypes = propTypesExact({
     column: PropTypes.object.isRequired,
     table: PropTypes.object.isRequired,

--- a/npm-api-maker/src/table/settings/column-row.jsx
+++ b/npm-api-maker/src/table/settings/column-row.jsx
@@ -9,8 +9,13 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "../../utils/text"
 import {View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object} column
+ * @property {object} table
+ * @property {object} tableSettingColumn
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ColumnRow extends BaseComponent {
   static propTypes = propTypesExact({
     column: PropTypes.object.isRequired,

--- a/npm-api-maker/src/table/settings/download-action.jsx
+++ b/npm-api-maker/src/table/settings/download-action.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable implicit-arrow-linebreak, react/jsx-no-literals, sort-imports */
-import BaseComponent from "../../base-component"
 import ColumnContent from "../column-content"
 import columnIdentifier from "../column-identifier.js"
 import columnVisible from "../column-visible.js"
@@ -10,7 +9,7 @@ import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import React from "react"
 import {renderToString} from "react-dom/server" // eslint-disable-line import/no-unresolved
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Pressable} from "react-native"
 import Text from "../../utils/text"
 
@@ -20,7 +19,7 @@ import Text from "../../utils/text"
  * @property {object} table
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableSettingsDownloadAction extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableSettingsDownloadAction extends ShapeComponent {
   static propTypes = propTypesExact({
     l: PropTypes.func.isRequired,
     table: PropTypes.object.isRequired

--- a/npm-api-maker/src/table/settings/download-action.jsx
+++ b/npm-api-maker/src/table/settings/download-action.jsx
@@ -14,8 +14,12 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Pressable} from "react-native"
 import Text from "../../utils/text"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {Function} l
+ * @property {object} table
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableSettingsDownloadAction extends BaseComponent {
   static propTypes = propTypesExact({
     l: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/settings/download-action.jsx
+++ b/npm-api-maker/src/table/settings/download-action.jsx
@@ -14,7 +14,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {Pressable} from "react-native"
 import Text from "../../utils/text"
 
-export default memo(shapeComponent(class ApiMakerTableSettingsDownloadAction extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableSettingsDownloadAction extends BaseComponent {
   static propTypes = propTypesExact({
     l: PropTypes.func.isRequired,
     table: PropTypes.object.isRequired

--- a/npm-api-maker/src/table/settings/index.jsx
+++ b/npm-api-maker/src/table/settings/index.jsx
@@ -13,8 +13,12 @@ import {View} from "react-native"
 import Text from "../../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {Function} onRequestClose
+ * @property {object} table
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableSettings extends BaseComponent {
   static propTypes = propTypesExact({
     onRequestClose: PropTypes.func.isRequired,

--- a/npm-api-maker/src/table/settings/index.jsx
+++ b/npm-api-maker/src/table/settings/index.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable implicit-arrow-linebreak, max-len, react/jsx-max-depth, sort-imports */
 import React, {useRef} from "react"
-import BaseComponent from "../../base-component"
 import columnIdentifier from "../column-identifier.js"
 import ColumnRow from "./column-row"
 import DownloadAction from "./download-action"
@@ -8,7 +7,7 @@ import memo from "set-state-compare/build/memo.js"
 import Modal from "../../modal"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {View} from "react-native"
 import Text from "../../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
@@ -19,7 +18,7 @@ import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
  * @property {object} table
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableSettings extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableSettings extends ShapeComponent {
   static propTypes = propTypesExact({
     onRequestClose: PropTypes.func.isRequired,
     table: PropTypes.object.isRequired

--- a/npm-api-maker/src/table/settings/index.jsx
+++ b/npm-api-maker/src/table/settings/index.jsx
@@ -13,7 +13,9 @@ import {View} from "react-native"
 import Text from "../../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
-export default memo(shapeComponent(class ApiMakerTableSettings extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableSettings extends BaseComponent {
   static propTypes = propTypesExact({
     onRequestClose: PropTypes.func.isRequired,
     table: PropTypes.object.isRequired

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -54,7 +54,9 @@ const paginationOptions = [30, 60, 90, ["All", "all"]]
 const styles = {}
 const TableContext = createContext(undefined)
 
-const ListHeaderComponent = memo(shapeComponent(class ListHeaderComponent extends BaseComponent {
+/** @typedef {object} HeaderProps */
+/** @typedef {object} HeaderState */
+const ListHeaderComponent = memo(shapeComponent(/** @augments {BaseComponent<HeaderProps, HeaderState>} */ class ListHeaderComponent extends BaseComponent {
   state = {
     lastUpdate: new Date()
   }
@@ -104,7 +106,9 @@ const ListHeaderComponent = memo(shapeComponent(class ListHeaderComponent extend
   onColumnVisibilityUpdated = () => this.setState({lastUpdate: new Date()})
 }))
 
-export default memo(shapeComponent(class ApiMakerTable extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTable extends BaseComponent {
   /**
    * @param {object} props
    */

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -196,7 +196,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     abilities: PropTypes.object,
     actionsContent: PropTypes.func,
     appHistory: PropTypes.object,
-    card: PropTypes.bool.isRequired,
+    card: PropTypes.bool,
     className: PropTypes.string,
     collection: PropTypes.instanceOf(Collection),
     columns: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
@@ -205,11 +205,11 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     defaultDateFormatName: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     defaultDateTimeFormatName: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
     defaultParams: PropTypes.object,
-    destroyEnabled: PropTypes.bool.isRequired,
+    destroyEnabled: PropTypes.bool,
     destroyMessage: PropTypes.string,
     draggedHeaderStyle: PropTypes.object,
     editModelPath: PropTypes.func,
-    filterCard: PropTypes.bool.isRequired,
+    filterCard: PropTypes.bool,
     filterContent: PropTypes.func,
     filterSubmitLabel: PropTypes.any,
     groupBy: PropTypes.array,
@@ -221,15 +221,15 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     onModelsLoaded: PropTypes.func,
     paginateContent: PropTypes.func,
     paginationComponent: PropTypes.elementType,
-    preloads: PropTypes.array.isRequired,
+    preloads: PropTypes.array,
     queryMethod: PropTypes.func,
     queryName: PropTypes.string,
     select: PropTypes.object,
     selectColumns: PropTypes.object,
     styles: PropTypes.object,
-    styleUI: PropTypes.bool.isRequired,
+    styleUI: PropTypes.bool,
     viewModelPath: PropTypes.func,
-    workplace: PropTypes.bool.isRequired
+    workplace: PropTypes.bool
   }
 
   draggableSortEvents = new EventEmitter()

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -5,7 +5,6 @@
 import {dig, digg, digs} from "diggerize"
 import React, {createContext, useContext, useEffect, useMemo, useRef} from "react"
 import {Animated, Platform, Pressable, View} from "react-native"
-import BaseComponent from "../base-component"
 import Card from "../bootstrap/card"
 import classNames from "classnames"
 import Collection from "../collection.js"
@@ -32,7 +31,7 @@ import Row from "./components/row"
 import selectCalculator from "./select-calculator.js"
 import Select from "../inputs/select"
 import Settings from "./settings/index"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import shouldRenderLoadingContent from "./should-render-loading-content.js"
 import TableSettings from "./table-settings.js"
 import Text from "../utils/text"
@@ -59,7 +58,7 @@ const TableContext = createContext(undefined)
  * @typedef {object} HeaderState
  * @property {Date} lastUpdate
  */
-const ListHeaderComponent = memo(shapeComponent(/** @augments {BaseComponent<HeaderProps, HeaderState>} */ class ListHeaderComponent extends BaseComponent {
+const ListHeaderComponent = memo(shapeComponent(/** @augments {ShapeComponent<HeaderProps, HeaderState>} */ class ListHeaderComponent extends ShapeComponent {
   state = {
     lastUpdate: new Date()
   }
@@ -174,7 +173,7 @@ const ListHeaderComponent = memo(shapeComponent(/** @augments {BaseComponent<Hea
  * @property {any} width
  * @property {any} widths
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTable extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTable extends ShapeComponent {
   /**
    * @param {object} props
    */

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -54,8 +54,11 @@ const paginationOptions = [30, 60, 90, ["All", "all"]]
 const styles = {}
 const TableContext = createContext(undefined)
 
-/** @typedef {object} HeaderProps */
-/** @typedef {object} HeaderState */
+/** @typedef {Record<string, never>} HeaderProps */
+/**
+ * @typedef {object} HeaderState
+ * @property {Date} lastUpdate
+ */
 const ListHeaderComponent = memo(shapeComponent(/** @augments {BaseComponent<HeaderProps, HeaderState>} */ class ListHeaderComponent extends BaseComponent {
   state = {
     lastUpdate: new Date()
@@ -106,8 +109,71 @@ const ListHeaderComponent = memo(shapeComponent(/** @augments {BaseComponent<Hea
   onColumnVisibilityUpdated = () => this.setState({lastUpdate: new Date()})
 }))
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} abilities
+ * @property {Function=} actionsContent
+ * @property {object=} appHistory
+ * @property {boolean=} card
+ * @property {string=} className
+ * @property {Collection=} collection
+ * @property {any[]|Function=} columns
+ * @property {Function=} controls
+ * @property {object=} currentUser
+ * @property {Function|string=} defaultDateFormatName
+ * @property {Function|string=} defaultDateTimeFormatName
+ * @property {object=} defaultParams
+ * @property {boolean=} destroyEnabled
+ * @property {string=} destroyMessage
+ * @property {object=} draggedHeaderStyle
+ * @property {Function=} editModelPath
+ * @property {boolean=} filterCard
+ * @property {Function=} filterContent
+ * @property {any=} filterSubmitLabel
+ * @property {any[]=} groupBy
+ * @property {Function|string=} header
+ * @property {string=} identifier
+ * @property {Function} modelClass
+ * @property {Function=} noRecordsAvailableContent
+ * @property {Function=} noRecordsFoundContent
+ * @property {Function=} onModelsLoaded
+ * @property {Function=} paginateContent
+ * @property {React.ComponentType<any>=} paginationComponent
+ * @property {any[]=} preloads
+ * @property {Function=} queryMethod
+ * @property {string=} queryName
+ * @property {object=} select
+ * @property {object=} selectColumns
+ * @property {object=} styles
+ * @property {boolean=} styleUI
+ * @property {Function=} viewModelPath
+ * @property {boolean=} workplace
+ */
+/**
+ * @typedef {object} State
+ * @property {any[]} columns
+ * @property {any} columnsToShow
+ * @property {object|undefined} currentWorkplace
+ * @property {any} currentWorkplaceCount
+ * @property {any} draggedColumn
+ * @property {any} filterForm
+ * @property {string} identifier
+ * @property {Date} lastUpdate
+ * @property {any} preload
+ * @property {any} preparedColumns
+ * @property {string} queryName
+ * @property {string} queryPageName
+ * @property {string} queryQName
+ * @property {string} querySName
+ * @property {boolean} resizing
+ * @property {boolean} showFilters
+ * @property {boolean} showSettings
+ * @property {any} tableSetting
+ * @property {string|undefined} tableSettingFullCacheKey
+ * @property {boolean} tableSettingLoaded
+ * @property {any} width
+ * @property {any} widths
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTable extends BaseComponent {
   /**
    * @param {object} props

--- a/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
@@ -10,8 +10,15 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {simpleObjectDifferent} from "set-state-compare/build/diff-utils.js"
 import useModelEvent from "../use-model-event.js"
 
-/** @typedef {object} CheckboxProps */
-/** @typedef {object} CheckboxState */
+/**
+ * @typedef {object} CheckboxProps
+ * @property {boolean=} checked
+ * @property {string=} className
+ * @property {boolean} indeterminate
+ * @property {Function=} onChange
+ * @property {object=} style
+ */
+/** @typedef {Record<string, never>} CheckboxState */
 const Checkbox = memo(shapeComponent(/** @augments {BaseComponent<CheckboxProps, CheckboxState>} */ class Checkbox extends BaseComponent {
   render() {
     const {indeterminate, ...restProps} = this.props
@@ -27,8 +34,17 @@ const Checkbox = memo(shapeComponent(/** @augments {BaseComponent<CheckboxProps,
   }
 }))
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {object=} currentWorkplace
+ * @property {Collection=} query
+ * @property {object=} style
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} checked
+ * @property {boolean} indeterminate
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckAllCheckbox extends BaseComponent {
   static propTypes = propTypesExact({
     currentWorkplace: PropTypes.object,

--- a/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
@@ -10,7 +10,9 @@ import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {simpleObjectDifferent} from "set-state-compare/build/diff-utils.js"
 import useModelEvent from "../use-model-event.js"
 
-const Checkbox = memo(shapeComponent(class Checkbox extends BaseComponent {
+/** @typedef {object} CheckboxProps */
+/** @typedef {object} CheckboxState */
+const Checkbox = memo(shapeComponent(/** @augments {BaseComponent<CheckboxProps, CheckboxState>} */ class Checkbox extends BaseComponent {
   render() {
     const {indeterminate, ...restProps} = this.props
     const checkboxRef = useRef(undefined)
@@ -25,7 +27,9 @@ const Checkbox = memo(shapeComponent(class Checkbox extends BaseComponent {
   }
 }))
 
-export default memo(shapeComponent(class ApiMakerTableWorkerPluginsCheckAllCheckbox extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckAllCheckbox extends BaseComponent {
   static propTypes = propTypesExact({
     currentWorkplace: PropTypes.object,
     query: PropTypes.instanceOf(Collection),

--- a/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
@@ -1,12 +1,11 @@
 /* eslint-disable import/no-unresolved, sort-imports */
 import React, {useEffect, useMemo, useRef} from "react"
-import BaseComponent from "../base-component"
 import classNames from "classnames"
 import Collection from "../collection.js"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {simpleObjectDifferent} from "set-state-compare/build/diff-utils.js"
 import useModelEvent from "../use-model-event.js"
 
@@ -19,7 +18,7 @@ import useModelEvent from "../use-model-event.js"
  * @property {object=} style
  */
 /** @typedef {Record<string, never>} CheckboxState */
-const Checkbox = memo(shapeComponent(/** @augments {BaseComponent<CheckboxProps, CheckboxState>} */ class Checkbox extends BaseComponent {
+const Checkbox = memo(shapeComponent(/** @augments {ShapeComponent<CheckboxProps, CheckboxState>} */ class Checkbox extends ShapeComponent {
   render() {
     const {indeterminate, ...restProps} = this.props
     const checkboxRef = useRef(undefined)
@@ -45,7 +44,7 @@ const Checkbox = memo(shapeComponent(/** @augments {BaseComponent<CheckboxProps,
  * @property {boolean} checked
  * @property {boolean} indeterminate
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckAllCheckbox extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckAllCheckbox extends ShapeComponent {
   static propTypes = propTypesExact({
     currentWorkplace: PropTypes.object,
     query: PropTypes.instanceOf(Collection),

--- a/npm-api-maker/src/table/worker-plugins-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-checkbox.jsx
@@ -12,8 +12,12 @@ import useModelEvent from "../use-model-event.js"
 
 const Workplace = modelClassRequire("Workplace")
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/**
+ * @typedef {object} State
+ * @property {boolean} checked
+ * @property {boolean} linkLoaded
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckbox extends BaseComponent {
   static propTypes = PropTypesExact({
     currentWorkplace: PropTypes.object,

--- a/npm-api-maker/src/table/worker-plugins-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-checkbox.jsx
@@ -12,7 +12,9 @@ import useModelEvent from "../use-model-event.js"
 
 const Workplace = modelClassRequire("Workplace")
 
-export default memo(shapeComponent(class ApiMakerTableWorkerPluginsCheckbox extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckbox extends BaseComponent {
   static propTypes = PropTypesExact({
     currentWorkplace: PropTypes.object,
     model: PropTypes.object.isRequired,

--- a/npm-api-maker/src/table/worker-plugins-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-checkbox.jsx
@@ -1,13 +1,12 @@
 /* eslint-disable import/no-unresolved, new-cap, sort-imports */
 import React, {useMemo} from "react"
-import BaseComponent from "../base-component"
 import classNames from "classnames"
 import {digg} from "diggerize"
 import memo from "set-state-compare/build/memo.js"
 import modelClassRequire from "../model-class-require.js"
 import PropTypes from "prop-types"
 import PropTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import useModelEvent from "../use-model-event.js"
 
 const Workplace = modelClassRequire("Workplace")
@@ -18,7 +17,7 @@ const Workplace = modelClassRequire("Workplace")
  * @property {boolean} checked
  * @property {boolean} linkLoaded
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckbox extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableWorkerPluginsCheckbox extends ShapeComponent {
   static propTypes = PropTypesExact({
     currentWorkplace: PropTypes.object,
     model: PropTypes.object.isRequired,

--- a/npm-api-maker/src/use-destroyed-event.js
+++ b/npm-api-maker/src/use-destroyed-event.js
@@ -49,7 +49,7 @@ class UseDestroyedEventShapeHook extends ShapeHook {
   }
 
   static propTypes = propTypesExact({
-    active: PropTypes.bool.isRequired,
+    active: PropTypes.bool,
     debounce: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.number

--- a/npm-api-maker/src/use-model-class-event.js
+++ b/npm-api-maker/src/use-model-class-event.js
@@ -14,7 +14,7 @@ class UseModelClassEventShapeHook extends ShapeHook {
   }
 
   static propTypes = propTypesExact({
-    active: PropTypes.bool.isRequired,
+    active: PropTypes.bool,
     debounce: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.number

--- a/npm-api-maker/src/utils/button.jsx
+++ b/npm-api-maker/src/utils/button.jsx
@@ -9,8 +9,22 @@ import React from "react"
 import Text from "./text"
 import {useForm} from "../form"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any=} children
+ * @property {boolean=} danger
+ * @property {boolean=} disabled
+ * @property {string=} icon
+ * @property {string=} label
+ * @property {Function=} onPress
+ * @property {object=} pressableProps
+ * @property {boolean=} submit
+ * @property {object=} textProps
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} hover
+ */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsButton extends ShapeComponent {
   static defaultProps = {
     children: null,

--- a/npm-api-maker/src/utils/button.jsx
+++ b/npm-api-maker/src/utils/button.jsx
@@ -40,14 +40,14 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
   static propTypes = propTypesExact({
     children: PropTypes.any,
-    danger: PropTypes.bool.isRequired,
-    disabled: PropTypes.bool.isRequired,
+    danger: PropTypes.bool,
+    disabled: PropTypes.bool,
     icon: PropTypes.string,
     label: PropTypes.string,
     onPress: PropTypes.func,
-    pressableProps: PropTypes.object.isRequired,
-    submit: PropTypes.bool.isRequired,
-    textProps: PropTypes.object.isRequired
+    pressableProps: PropTypes.object,
+    submit: PropTypes.bool,
+    textProps: PropTypes.object
   })
 
   state = {

--- a/npm-api-maker/src/utils/button.jsx
+++ b/npm-api-maker/src/utils/button.jsx
@@ -9,7 +9,9 @@ import React from "react"
 import Text from "./text"
 import {useForm} from "../form"
 
-export default memo(shapeComponent(class ApiMakerUtilsButton extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsButton extends ShapeComponent {
   static defaultProps = {
     children: null,
     danger: false,

--- a/npm-api-maker/src/utils/card.jsx
+++ b/npm-api-maker/src/utils/card.jsx
@@ -8,7 +8,9 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import Text from "./text"
 import {View} from "react-native"
 
-export default memo(shapeComponent(class ApiMakerUtilsCard extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsCard extends ShapeComponent {
   static propTypes = propTypesExact({
     children: PropTypes.any,
     controls: PropTypes.any,

--- a/npm-api-maker/src/utils/card.jsx
+++ b/npm-api-maker/src/utils/card.jsx
@@ -8,8 +8,16 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import Text from "./text"
 import {View} from "react-native"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {any=} children
+ * @property {any=} controls
+ * @property {object=} dataSet
+ * @property {string=} header
+ * @property {object=} style
+ * @property {string=} testID
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsCard extends ShapeComponent {
   static propTypes = propTypesExact({
     children: PropTypes.any,

--- a/npm-api-maker/src/utils/checkbox.jsx
+++ b/npm-api-maker/src/utils/checkbox.jsx
@@ -9,7 +9,9 @@ import propTypesExact from "prop-types-exact"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "./text"
 
-export default memo(shapeComponent(class ApiMakerUtilsCheckbox extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsCheckbox extends BaseComponent {
   static defaultProps = {
     dataSet: null,
     label: undefined,

--- a/npm-api-maker/src/utils/checkbox.jsx
+++ b/npm-api-maker/src/utils/checkbox.jsx
@@ -9,8 +9,20 @@ import propTypesExact from "prop-types-exact"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "./text"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {boolean=} checked
+ * @property {object=} dataSet
+ * @property {boolean=} defaultChecked
+ * @property {string=} label
+ * @property {Function=} onCheckedChange
+ * @property {object=} style
+ * @property {string=} testID
+ */
+/**
+ * @typedef {object} State
+ * @property {any} checked
+ */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsCheckbox extends BaseComponent {
   static defaultProps = {
     dataSet: null,

--- a/npm-api-maker/src/utils/checkbox.jsx
+++ b/npm-api-maker/src/utils/checkbox.jsx
@@ -2,11 +2,10 @@
 // @ts-expect-error CheckBox removed from react-native core in newer versions
 import {CheckBox, Pressable, View} from "react-native"
 import React, {useMemo} from "react"
-import BaseComponent from "../base-component"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "./text"
 
 /**
@@ -23,7 +22,7 @@ import Text from "./text"
  * @typedef {object} State
  * @property {any} checked
  */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsCheckbox extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsCheckbox extends ShapeComponent {
   static defaultProps = {
     dataSet: null,
     label: undefined,

--- a/npm-api-maker/src/utils/checkboxes.jsx
+++ b/npm-api-maker/src/utils/checkboxes.jsx
@@ -13,8 +13,14 @@ import Text from "./text"
 import useInput from "../use-input.js"
 import {View} from "react-native"
 
-/** @typedef {object} OptionElementProps */
-/** @typedef {object} OptionElementState */
+/**
+ * @typedef {object} OptionElementProps
+ * @property {boolean} checked
+ * @property {string} inputName
+ * @property {Function} onChange
+ * @property {any[]} option
+ */
+/** @typedef {Record<string, never>} OptionElementState */
 const OptionElement = memo(shapeComponent(/** @augments {ShapeComponent<OptionElementProps, OptionElementState>} */ class OptionElement extends ShapeComponent {
   static propTypes = propTypesExact({
     checked: PropTypes.bool.isRequired,
@@ -46,8 +52,21 @@ const OptionElement = memo(shapeComponent(/** @augments {ShapeComponent<OptionEl
   onChange = (checked) => this.p.onChange({checked, option: this.p.option})
 }))
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string=} attribute
+ * @property {any[]=} defaultValue
+ * @property {string=} label
+ * @property {string=} labelClassName
+ * @property {object=} model
+ * @property {string=} name
+ * @property {Function=} onChange
+ * @property {any[]} options
+ */
+/**
+ * @typedef {object} State
+ * @property {any} checkedOptions
+ */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsCheckboxes extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,

--- a/npm-api-maker/src/utils/checkboxes.jsx
+++ b/npm-api-maker/src/utils/checkboxes.jsx
@@ -13,7 +13,9 @@ import Text from "./text"
 import useInput from "../use-input.js"
 import {View} from "react-native"
 
-const OptionElement = memo(shapeComponent(class OptionElement extends ShapeComponent {
+/** @typedef {object} OptionElementProps */
+/** @typedef {object} OptionElementState */
+const OptionElement = memo(shapeComponent(/** @augments {ShapeComponent<OptionElementProps, OptionElementState>} */ class OptionElement extends ShapeComponent {
   static propTypes = propTypesExact({
     checked: PropTypes.bool.isRequired,
     inputName: PropTypes.string.isRequired,
@@ -44,7 +46,9 @@ const OptionElement = memo(shapeComponent(class OptionElement extends ShapeCompo
   onChange = (checked) => this.p.onChange({checked, option: this.p.option})
 }))
 
-export default memo(shapeComponent(class ApiMakerUtilsCheckboxes extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsCheckboxes extends ShapeComponent {
   static propTypes = propTypesExact({
     attribute: PropTypes.string,
     defaultValue: PropTypes.array,

--- a/npm-api-maker/src/utils/icon.jsx
+++ b/npm-api-maker/src/utils/icon.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-multi-spaces, prefer-object-spread, sort-imports */
-import BaseComponent from "../base-component"
 import FontAwesomeIcon from "react-native-vector-icons/FontAwesome.js"
 import FontAwesome5Icon from "react-native-vector-icons/FontAwesome5.js"
 import FontAwesome6Icon from "react-native-vector-icons/FontAwesome6.js"
@@ -8,7 +7,7 @@ import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import React, {useMemo} from "react"
 import {StyleSheet} from "react-native"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useMergedStyle} from "./default-style"
 
 const FontAwesomeGlyphMap = FontAwesomeIcon.getRawGlyphMap()
@@ -32,7 +31,7 @@ const iconMap = {
  * @property {("FontAwesome"|"FontAwesome5"|"FontAwesome6"|"MaterialIcons")=} version
  */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsIcon extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsIcon extends ShapeComponent {
   /** @type {Props} */
   static propTypes = {
     color: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/npm-api-maker/src/utils/icon.jsx
+++ b/npm-api-maker/src/utils/icon.jsx
@@ -23,7 +23,7 @@ const iconMap = {
 }
 
 /**
- * @typedef {object} ApiMakerUtilsIconProps
+ * @typedef {object} Props
  * @property {string|number=} color
  * @property {object=} dataSet
  * @property {string} name
@@ -31,8 +31,9 @@ const iconMap = {
  * @property {import("react-native").StyleProp<import("react-native").TextStyle>=} style Only `color` is forwarded.
  * @property {("FontAwesome"|"FontAwesome5"|"FontAwesome6"|"MaterialIcons")=} version
  */
-export default memo(shapeComponent(class ApiMakerUtilsIcon extends BaseComponent {
-  /** @type {ApiMakerUtilsIconProps} */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsIcon extends BaseComponent {
+  /** @type {Props} */
   static propTypes = {
     color: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     dataSet: PropTypes.object,

--- a/npm-api-maker/src/utils/icon.jsx
+++ b/npm-api-maker/src/utils/icon.jsx
@@ -31,7 +31,7 @@ const iconMap = {
  * @property {import("react-native").StyleProp<import("react-native").TextStyle>=} style Only `color` is forwarded.
  * @property {("FontAwesome"|"FontAwesome5"|"FontAwesome6"|"MaterialIcons")=} version
  */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsIcon extends BaseComponent {
   /** @type {Props} */
   static propTypes = {

--- a/npm-api-maker/src/utils/invalid-feedback.jsx
+++ b/npm-api-maker/src/utils/invalid-feedback.jsx
@@ -6,7 +6,9 @@ import propTypesExact from "prop-types-exact"
 import React from "react"
 import Text from "./text"
 
-export default memo(shapeComponent(class ApiMakerUtilsInvalidFeedback extends ShapeComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsInvalidFeedback extends ShapeComponent {
   static propTypes = propTypesExact({
     message: PropTypes.string.isRequired
   })

--- a/npm-api-maker/src/utils/invalid-feedback.jsx
+++ b/npm-api-maker/src/utils/invalid-feedback.jsx
@@ -6,8 +6,11 @@ import propTypesExact from "prop-types-exact"
 import React from "react"
 import Text from "./text"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/**
+ * @typedef {object} Props
+ * @property {string} message
+ */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsInvalidFeedback extends ShapeComponent {
   static propTypes = propTypesExact({
     message: PropTypes.string.isRequired

--- a/npm-api-maker/src/utils/modal.jsx
+++ b/npm-api-maker/src/utils/modal.jsx
@@ -1,16 +1,15 @@
-/* eslint-disable implicit-arrow-linebreak, prefer-object-spread, sort-vars */
-import {Modal, Pressable, View} from "react-native"
+/* eslint-disable implicit-arrow-linebreak, prefer-object-spread, sort-imports, sort-vars */
 import React, {useMemo} from "react"
-import BaseComponent from "../base-component"
+import {Modal, Pressable, View} from "react-native"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
+import {useBreakpoint} from "responsive-breakpoints"
 import Card from "./card"
 import Icon from "../utils/icon"
 import memo from "set-state-compare/build/memo.js"
-import {shapeComponent} from "set-state-compare/build/shape-component.js"
-import {useBreakpoint} from "responsive-breakpoints"
 
 /** @typedef {Record<string, never>} Props */
 /** @typedef {Record<string, never>} State */
-export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsComponent extends BaseComponent {
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsComponent extends ShapeComponent {
   render() {
     const {smDown} = useBreakpoint()
     const {children, dataSet, ...restProps} = this.props

--- a/npm-api-maker/src/utils/modal.jsx
+++ b/npm-api-maker/src/utils/modal.jsx
@@ -8,7 +8,9 @@ import memo from "set-state-compare/build/memo.js"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useBreakpoint} from "responsive-breakpoints"
 
-export default memo(shapeComponent(class ApiMakerUtilsComponent extends BaseComponent {
+/** @typedef {object} Props */
+/** @typedef {object} State */
+export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsComponent extends BaseComponent {
   render() {
     const {smDown} = useBreakpoint()
     const {children, dataSet, ...restProps} = this.props

--- a/npm-api-maker/src/utils/modal.jsx
+++ b/npm-api-maker/src/utils/modal.jsx
@@ -8,8 +8,8 @@ import memo from "set-state-compare/build/memo.js"
 import {shapeComponent} from "set-state-compare/build/shape-component.js"
 import {useBreakpoint} from "responsive-breakpoints"
 
-/** @typedef {object} Props */
-/** @typedef {object} State */
+/** @typedef {Record<string, never>} Props */
+/** @typedef {Record<string, never>} State */
 export default memo(shapeComponent(/** @augments {BaseComponent<Props, State>} */ class ApiMakerUtilsComponent extends BaseComponent {
   render() {
     const {smDown} = useBreakpoint()

--- a/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-that-signs-out-on-mount.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-that-signs-out-on-mount.jsx
@@ -2,8 +2,8 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import Devise from "@kaspernj/api-maker/build/devise.js"
 import {memo, useMemo} from "react"
 
-/** @typedef {object} LoaderThatSignsOutOnMountProps */
-/** @typedef {object} LoaderThatSignsOutOnMountState */
+/** @typedef {Record<string, never>} LoaderThatSignsOutOnMountProps */
+/** @typedef {Record<string, never>} LoaderThatSignsOutOnMountState */
 export default memo(shapeComponent(/** @augments {ShapeComponent<LoaderThatSignsOutOnMountProps, LoaderThatSignsOutOnMountState>} */ class LoaderThatSignsOutOnMount extends ShapeComponent {
   setup() {
     useMemo(() => {

--- a/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-that-signs-out-on-mount.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-that-signs-out-on-mount.jsx
@@ -2,7 +2,9 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import Devise from "@kaspernj/api-maker/build/devise.js"
 import {memo, useMemo} from "react"
 
-export default memo(shapeComponent(class LoaderThatSignsOutOnMount extends ShapeComponent {
+/** @typedef {object} LoaderThatSignsOutOnMountProps */
+/** @typedef {object} LoaderThatSignsOutOnMountState */
+export default memo(shapeComponent(/** @augments {ShapeComponent<LoaderThatSignsOutOnMountProps, LoaderThatSignsOutOnMountState>} */ class LoaderThatSignsOutOnMount extends ShapeComponent {
   setup() {
     useMemo(() => {
       Devise.signOut()

--- a/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-with-state.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-with-state.jsx
@@ -11,7 +11,9 @@ import Text from "@kaspernj/api-maker/build/utils/text"
 import useCanCan from "@kaspernj/api-maker/build/use-can-can.js"
 import useCurrentUser from "@kaspernj/api-maker/build/use-current-user.js"
 
-export default memo(shapeComponent(class CanCanWithState extends ShapeComponent {
+/** @typedef {object} CanCanWithStateProps */
+/** @typedef {object} CanCanWithStateState */
+export default memo(shapeComponent(/** @augments {ShapeComponent<CanCanWithStateProps, CanCanWithStateState>} */ class CanCanWithState extends ShapeComponent {
   static propTypes = {
     className: PropTypes.string
   }

--- a/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-with-state.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/components/can-can/loader-with-state.jsx
@@ -11,8 +11,11 @@ import Text from "@kaspernj/api-maker/build/utils/text"
 import useCanCan from "@kaspernj/api-maker/build/use-can-can.js"
 import useCurrentUser from "@kaspernj/api-maker/build/use-current-user.js"
 
-/** @typedef {object} CanCanWithStateProps */
-/** @typedef {object} CanCanWithStateState */
+/**
+ * @typedef {object} CanCanWithStateProps
+ * @property {string=} className
+ */
+/** @typedef {Record<string, never>} CanCanWithStateState */
 export default memo(shapeComponent(/** @augments {ShapeComponent<CanCanWithStateProps, CanCanWithStateState>} */ class CanCanWithState extends ShapeComponent {
   static propTypes = {
     className: PropTypes.string

--- a/ruby-gem/spec/dummy/app/javascript/routes/bootstrap/sort-link.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/bootstrap/sort-link.jsx
@@ -7,7 +7,7 @@ import SortLink from "@kaspernj/api-maker/build/bootstrap/sort-link"
 import {Task} from "models.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 
-/** @typedef {object} BootstrapSortLinkProps */
+/** @typedef {Record<string, never>} BootstrapSortLinkProps */
 
 /**
  * @typedef {object} BootstrapSortLinkState

--- a/ruby-gem/spec/dummy/app/javascript/routes/can-can/loader.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/can-can/loader.jsx
@@ -6,7 +6,7 @@ import Layout from "components/layout"
 import LoaderThatSignsOutOnMount from "components/can-can/loader-that-signs-out-on-mount"
 import LoaderWithState from "components/can-can/loader-with-state"
 
-/** @typedef {object} RoutesCanCanLoaderProps */
+/** @typedef {Record<string, never>} RoutesCanCanLoaderProps */
 
 /**
  * @typedef {object} RoutesCanCanLoaderState

--- a/ruby-gem/spec/dummy/app/javascript/routes/devise/events.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/devise/events.jsx
@@ -11,7 +11,7 @@ import Layout from "components/layout"
 import {Task, User} from "models.js"
 import useEventEmitter from "ya-use-event-emitter"
 
-/** @typedef {object} DeviseEventsProps */
+/** @typedef {Record<string, never>} DeviseEventsProps */
 
 /**
  * @typedef {object} DeviseEventsState

--- a/ruby-gem/spec/dummy/app/javascript/routes/models/created-event.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/models/created-event.jsx
@@ -4,7 +4,7 @@ import Layout from "components/layout"
 import {Task} from "models.js"
 import useCreatedEvent from "@kaspernj/api-maker/build/use-created-event.js"
 
-/** @typedef {object} ModelsCreatedEventProps */
+/** @typedef {Record<string, never>} ModelsCreatedEventProps */
 
 /**
  * @typedef {object} ModelsCreatedEventState

--- a/ruby-gem/spec/dummy/app/javascript/routes/models/destroy-event.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/models/destroy-event.jsx
@@ -4,7 +4,7 @@ import {Task} from "models.js"
 import useDestroyedEvent from "@kaspernj/api-maker/build/use-destroyed-event"
 
 /** @typedef {{task: Task}} TaskRowProps */
-/** @typedef {object} TaskRowState */
+/** @typedef {Record<string, never>} TaskRowState */
 /** @augments {ShapeComponent<TaskRowProps, TaskRowState>} */
 class TaskRow extends ShapeComponent {
   render() {
@@ -20,7 +20,7 @@ class TaskRow extends ShapeComponent {
 
 const MemoizedTaskRow = memo(shapeComponent(TaskRow))
 
-/** @typedef {object} ModelsDestroyEventProps */
+/** @typedef {Record<string, never>} ModelsDestroyEventProps */
 
 /**
  * @typedef {object} ModelsDestroyEventState

--- a/ruby-gem/spec/dummy/app/javascript/routes/models/destroy-event.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/models/destroy-event.jsx
@@ -4,8 +4,8 @@ import {Task} from "models.js"
 import useDestroyedEvent from "@kaspernj/api-maker/build/use-destroyed-event"
 
 /** @typedef {{task: Task}} TaskRowProps */
-
-/** @augments {ShapeComponent<TaskRowProps>} */
+/** @typedef {object} TaskRowState */
+/** @augments {ShapeComponent<TaskRowProps, TaskRowState>} */
 class TaskRow extends ShapeComponent {
   render() {
     const {task} = this.p

--- a/ruby-gem/spec/dummy/app/javascript/routes/models/model-event.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/models/model-event.jsx
@@ -6,7 +6,7 @@ import Text from "@kaspernj/api-maker/build/utils/text"
 import {Task} from "models.js"
 import useModelEvent from "@kaspernj/api-maker/build/use-model-event.js"
 
-/** @typedef {object} ModelsModelEventProps */
+/** @typedef {Record<string, never>} ModelsModelEventProps */
 
 /**
  * @typedef {object} ModelsModelEventState

--- a/ruby-gem/spec/dummy/app/javascript/routes/models/paginate.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/models/paginate.jsx
@@ -6,7 +6,7 @@ import SortLink from "@kaspernj/api-maker/build/bootstrap/sort-link"
 import {Task} from "models.js"
 import useQueryParams from "on-location-changed/build/use-query-params.js"
 
-/** @typedef {object} ModelsPaginateProps */
+/** @typedef {Record<string, never>} ModelsPaginateProps */
 
 /**
  * @typedef {object} ModelsPaginateState

--- a/ruby-gem/spec/dummy/app/javascript/routes/models/update-event.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/models/update-event.jsx
@@ -4,7 +4,7 @@ import React from "react"
 import {Task} from "models.js"
 import useUpdatedEvent from "@kaspernj/api-maker/build/use-updated-event.js"
 
-/** @typedef {object} ModelsUpdateEventProps */
+/** @typedef {Record<string, never>} ModelsUpdateEventProps */
 
 /**
  * @typedef {object} ModelsUpdateEventState

--- a/ruby-gem/spec/dummy/app/javascript/routes/session-status-specs/timeout.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/session-status-specs/timeout.jsx
@@ -5,7 +5,7 @@ import Layout from "components/layout"
 import useEventEmitter from "ya-use-event-emitter"
 import SessionStatusUpdater from "@kaspernj/api-maker/build/session-status-updater.js"
 
-/** @typedef {object} SessionStatusSpecsTimeoutProps */
+/** @typedef {Record<string, never>} SessionStatusSpecsTimeoutProps */
 
 /**
  * @typedef {object} SessionStatusSpecsTimeoutState

--- a/ruby-gem/spec/dummy/app/javascript/routes/sessions/new.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/sessions/new.jsx
@@ -7,7 +7,7 @@ import Input from "@kaspernj/api-maker/build/bootstrap/input"
 import Layout from "components/layout"
 import useEventEmitter from "ya-use-event-emitter"
 
-/** @typedef {object} SessionsNewProps */
+/** @typedef {Record<string, never>} SessionsNewProps */
 
 /**
  * @typedef {object} SessionsNewState

--- a/ruby-gem/spec/dummy/app/javascript/routes/super-admin.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/super-admin.jsx
@@ -5,7 +5,9 @@ import React from "react"
 import SuperAdmin from "@kaspernj/api-maker/build/super-admin"
 import useCurrentUser from "@kaspernj/api-maker/build/use-current-user.js"
 
-export default memo(shapeComponent(class RoutesSuperAdmin extends ShapeComponent {
+/** @typedef {object} RoutesSuperAdminProps */
+/** @typedef {object} RoutesSuperAdminState */
+export default memo(shapeComponent(/** @augments {ShapeComponent<RoutesSuperAdminProps, RoutesSuperAdminState>} */ class RoutesSuperAdmin extends ShapeComponent {
   static propTypes = {
     currentUser: PropTypes.object
   }

--- a/ruby-gem/spec/dummy/app/javascript/routes/super-admin.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/super-admin.jsx
@@ -5,8 +5,11 @@ import React from "react"
 import SuperAdmin from "@kaspernj/api-maker/build/super-admin"
 import useCurrentUser from "@kaspernj/api-maker/build/use-current-user.js"
 
-/** @typedef {object} RoutesSuperAdminProps */
-/** @typedef {object} RoutesSuperAdminState */
+/**
+ * @typedef {object} RoutesSuperAdminProps
+ * @property {object=} currentUser
+ */
+/** @typedef {Record<string, never>} RoutesSuperAdminState */
 export default memo(shapeComponent(/** @augments {ShapeComponent<RoutesSuperAdminProps, RoutesSuperAdminState>} */ class RoutesSuperAdmin extends ShapeComponent {
   static propTypes = {
     currentUser: PropTypes.object


### PR DESCRIPTION
## Summary
- add explicit props/state JSDoc typedefs and `@augments` annotations to ShapeComponent-based components across `npm-api-maker`
- add the same annotations to the affected dummy app ShapeComponents used in system specs
- make `BaseComponent` generic so subclasses can declare their props/state types cleanly

## Validation
- `cd npm-api-maker && npm run lint:eslint -- <changed files>`
- `cd npm-api-maker && npm run typecheck`
- `cd npm-api-maker && npm run build`
- shape-component JSDoc audit script across `npm-api-maker/src` and `ruby-gem/spec/dummy/app/javascript`

## Notes
- `cd ruby-gem/spec/dummy && RAILS_ENV=development bin/shakapacker` currently fails in this workspace because the linked `@kaspernj/api-maker` package is resolving package subpaths inconsistently in the dummy app. `require.resolve('@kaspernj/api-maker/build/devise.js')` succeeds and the built files exist, so this does not appear to be caused by the JSDoc changes in this PR.