### PR TITLE
Expose Channel#sync_api_maker_current_user! as a public helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,12 @@ If you prefer controlled inputs, use the `value` argument instead of `defaultVal
 
 ### ActionCable
 
-Your `connection.rb` should look something like this:
+ApiMaker can run commands, services, and model subscriptions over your app's existing ActionCable connection. The setup has three parts: your `Connection` identifies the current user, your `Channel` inherits from `ApiMaker::Channel` so `current_user` / `current_ability` / `api_maker_args` stay in sync with the user on the connection, and the frontend opts into websocket-transported requests.
+
+#### Connection
+
+`ApplicationCable::Connection` authenticates the websocket upgrade and exposes `current_user` via `identified_by`. Because the websocket handshake only happens once per connection, `find_verified_user` is typically fed from the same signed cookies your HTTP sign-in flow writes (see the "Sign-in across HTTP and websocket" section below):
+
 ```rb
 class ApplicationCable::Connection < ActionCable::Connection::Base
   identified_by :current_user
@@ -259,22 +264,32 @@ private
 end
 ```
 
-Your `channel.rb` should look something like this:
+#### Channel
+
+Inherit from `ApiMaker::Channel`. It wires up `current_user`, `current_ability`, `api_maker_args`, and the session-shadow store for you — don't reimplement them, just extend. Adding per-request state (time zones, SQL session variables, audit context) goes through an optional `with_request_context` hook that ApiMaker calls once per command:
+
 ```rb
-class ApplicationCable::Channel < ActionCable::Channel::Base
-private # rubocop:disable Layout/IndentationWidth
+class ApplicationCable::Channel < ApiMaker::Channel
+  def with_request_context(api_maker_args:, &)
+    # Force the channel to re-read the current user from the connection's
+    # in-memory warden proxy before each command. Critical when a user signs in
+    # mid-connection over HTTP — `Devise::PersistSession` running on this
+    # cable updates `warden.user(:user)` but not the session store captured at
+    # upgrade, so reading `warden.session_serializer` would clobber a valid
+    # signed-in user with nil. `sync_api_maker_current_user!` does the right
+    # read for you.
+    sync_api_maker_current_user!
 
-  def current_ability
-    @current_ability ||= ApiMakerAbility.for_user(current_user)
-  end
-
-  def current_user
-    @current_user ||= env["warden"].user
+    yield
   end
 end
 ```
 
-To send ApiMaker commands and services over ActionCable instead of the HTTP commands endpoint, enable websocket requests in the frontend config:
+If your resource abilities rely on `current_user` being set inside `api_maker_args` (via `resource.current_user`), the inherited `ApiMaker::Channel#current_ability` already passes it through correctly. You only need a custom `with_request_context` when you have additional per-command state (SQL vars, time zone, audit trail, etc.) to set up around each command.
+
+#### Sending commands over the websocket
+
+To route ApiMaker model queries, services, and commands through the cable instead of the HTTP `/api_maker/commands` endpoint, enable websocket requests in the frontend config once during app bootstrap:
 
 ```js
 import ApiMakerConfig from "@kaspernj/api-maker/build/config.js"
@@ -282,7 +297,26 @@ import ApiMakerConfig from "@kaspernj/api-maker/build/config.js"
 ApiMakerConfig.setWebsocketRequests(true)
 ```
 
-ApiMaker automatically installs its session-shadow middleware so websocket-side session changes can be observed by later HTTP requests. Your ActionCable channel still needs to expose the same request context that your normal controllers provide. In practice that means `current_user`, the CanCan ability, and any `api_maker_args` data needed by serializers and commands.
+From that point onward, any `Model.ransack(...).toArray()`, `Model.ransack(...).first()`, `useCollection(...)`, `useModel(...)`, and `Services.current().sendRequest(...)` call will go over ActionCable and be handled by `ApiMaker::RequestsChannel`. Requests that must set a cookie — sign-in, sign-out, session persistence — still force HTTP internally (`{forceHttp: true}`) because ActionCable has no response headers to carry `Set-Cookie` on.
+
+Model event subscriptions (`useCollection`, `useModel`, create/update/destroy listeners) always go through `ApiMaker::SubscriptionsChannel`, regardless of `setWebsocketRequests`.
+
+#### Sign-in across HTTP and websocket
+
+The non-obvious case is signing in while an ActionCable connection is already open. The flow:
+
+1. The frontend calls `Devise.signIn`. This POSTs over HTTP (the server needs `Set-Cookie` headers), and Devise sets the session cookie plus any signed cookies your `Warden::Manager.after_set_user` hook writes.
+2. `Devise.signIn` then sends `Devise::PersistSession` over the **existing** cable so the backend can sync the connection's identity to the new user. On the server, that command resolves the new user from the shadow session token and calls `controller.sign_in(user)` inside `ApiMaker::ActionCableRequestContext`, which invokes `warden.set_user` and `update_api_maker_current_user!` — updating warden's in-memory proxy, the channel's cached `@current_user`, and `connection.current_user` (the `identified_by` slot).
+3. The next websocket command runs with `current_user` set to the signed-in user.
+
+What can trip this up in your channel:
+
+- Overriding `current_user` to re-read from `warden.session_serializer.fetch(:user)` or `env["rack.session"]`. The rack session captured at cable upgrade is not refreshed when the HTTP sign-in happens later, so you'll read nil and wipe a valid signed-in user. Always read from `warden.user(:user)` (the in-memory proxy) if you must read from warden directly — or, better, just call `sync_api_maker_current_user!` and let ApiMaker do it.
+- Forgetting to send `Devise.signIn`'s second-half `PersistSession` and instead doing your own HTTP sign-in endpoint. Use `Devise.signIn` (or, for impersonation, `Devise.persistSession` followed by `resetRealtimeRuntimeState()` to tear down and reopen the cable with the new cookies).
+
+#### Session shadow middleware
+
+ApiMaker automatically installs `ApiMaker::SessionShadowMiddleware` so websocket-side session changes become visible to later HTTP requests and vice versa. You don't need to mount it yourself — the railtie does it during Rails boot.
 
 ## Usage
 

--- a/ruby-gem/app/channels/api_maker/channel.rb
+++ b/ruby-gem/app/channels/api_maker/channel.rb
@@ -49,18 +49,19 @@ class ApiMaker::Channel < ActionCable::Channel::Base
     @current_user
   end
 
-private
-
-  def current_request
-    if connection.respond_to?(:request)
-      connection.request
-    else
-      ActionDispatch::Request.new(connection.env)
-    end
-  end
-
-  def handle_api_maker_current_user_change(previous_user:, current_user:); end
-
+  # Reconciles the channel's cached current_user with the authoritative
+  # in-memory sources on the connection. Reads `connection.current_user`
+  # (set by ActionCable `identified_by :current_user` and mutated by
+  # `sign_in(model)` inside `ApiMaker::ActionCableRequestContext`) and falls
+  # back to `env["warden"]&.user(:user)` — the warden proxy's in-memory
+  # `@users[:user]`, which `warden.set_user` updates during
+  # `Devise::PersistSession` on the cable.
+  #
+  # Call this from custom `with_request_context` overrides that want to
+  # force a pre-command refresh. Do NOT read `warden.session_serializer`
+  # directly — the rack session captured at cable upgrade is not refreshed
+  # when a user signs in mid-connection over HTTP, so reading that source
+  # will clobber a valid signed-in user with nil.
   def sync_api_maker_current_user!
     synced_current_user = if connection.respond_to?(:current_user) && connection.current_user.present?
       connection.current_user
@@ -72,4 +73,16 @@ private
 
     update_api_maker_current_user!(synced_current_user)
   end
+
+private
+
+  def current_request
+    if connection.respond_to?(:request)
+      connection.request
+    else
+      ActionDispatch::Request.new(connection.env)
+    end
+  end
+
+  def handle_api_maker_current_user_change(previous_user:, current_user:); end
 end

--- a/ruby-gem/spec/channels/api_maker/channel_spec.rb
+++ b/ruby-gem/spec/channels/api_maker/channel_spec.rb
@@ -20,6 +20,69 @@ describe ApiMaker::Channel do
     end
   end
 
+  describe "#sync_api_maker_current_user!" do
+    let(:warden) { instance_double(Warden::Proxy) }
+    let(:connection) do
+      instance_double(ApplicationCable::Connection, env: {"warden" => warden})
+    end
+    let(:channel) do
+      channel_connection = connection
+      channel = described_class.allocate
+      channel.define_singleton_method(:connection) { channel_connection }
+      channel
+    end
+
+    before do
+      # respond_to? gets called by RSpec internals as well as the implementation
+      # under test, so keep this as a stub rather than an expectation.
+      allow(connection).to receive(:respond_to?) do |method_name|
+        [:current_user, :current_user=].include?(method_name)
+      end
+    end
+
+    it "prefers connection.current_user when present" do
+      expect(connection).to receive(:current_user).twice.and_return("connection-user")
+      expect(connection).to receive(:current_user=).with("connection-user")
+
+      expect(channel.sync_api_maker_current_user!).to eq("connection-user")
+      expect(channel.instance_variable_get(:@current_user)).to eq("connection-user")
+    end
+
+    it "falls back to the in-memory warden proxy user when connection.current_user is nil" do
+      expect(connection).to receive(:current_user).and_return(nil)
+      expect(warden).to receive(:user).with(:user).and_return("warden-user")
+      expect(connection).to receive(:current_user=).with("warden-user")
+
+      expect(channel.sync_api_maker_current_user!).to eq("warden-user")
+      expect(channel.instance_variable_get(:@current_user)).to eq("warden-user")
+    end
+
+    # Regression: `warden.set_user` on an ActionCable command updates
+    # `warden.user(:user)` but cannot write to the cable-upgrade rack
+    # session. Reading from the session store (via
+    # `warden.session_serializer.fetch(:user)`) would clobber a valid
+    # just-signed-in user with nil. This spec keeps the preferred source
+    # pinned to warden's in-memory proxy.
+    it "does not consult warden.session_serializer" do
+      expect(connection).to receive(:current_user).and_return(nil)
+      expect(warden).to receive(:user).with(:user).and_return("warden-user")
+      expect(connection).to receive(:current_user=).with("warden-user")
+      expect(warden).not_to receive(:session_serializer)
+
+      channel.sync_api_maker_current_user!
+    end
+
+    it "clears @current_user when neither source reports a user" do
+      channel.instance_variable_set(:@current_user, "stale-user")
+      expect(connection).to receive(:current_user).and_return(nil)
+      expect(warden).to receive(:user).with(:user).and_return(nil)
+      expect(connection).to receive(:current_user=).with(nil)
+
+      expect(channel.sync_api_maker_current_user!).to be_nil
+      expect(channel.instance_variable_get(:@current_user)).to be_nil
+    end
+  end
+
   describe "#current_ability" do
     it "includes the current session id in api_maker args" do
       connection = instance_double(ApplicationCable::Connection, env: {}, current_user: nil)


### PR DESCRIPTION
## Summary
`ApiMaker::Channel#sync_api_maker_current_user!` was private. Downstream projects that want to force a pre-command `current_user` refresh from inside a custom `with_request_context` override had to reinvent the warden read themselves. At least one downstream (wooftech) got the reinvention wrong:

```ruby
def sync_current_user_from_warden!
  warden = connection.env["warden"]
  warden_current_user = warden&.session_serializer&.fetch(:user)
  return if current_user == warden_current_user
  update_api_maker_current_user!(warden_current_user)
end
```

Reading `warden.session_serializer.fetch(:user)` inside a websocket command silently wipes a valid signed-in user. `Devise::PersistSession` on the cable updates the warden proxy's in-memory `@users[:user]` via `warden.set_user`, but it cannot write back to the rack session captured at cable upgrade. The session store stays empty, and the next command's `sync_current_user_from_warden!` reads nil and overrides the channel's just-signed-in user. Downstream user-visible symptom: sign-in succeeds, flash says so, but the sign-in form stays on screen while follow-up self-lookup queries return 0 rows.

## Changes
- Make `sync_api_maker_current_user!` public and document which sources it reads and which it must not (`warden.session_serializer`).
- Add specs pinning the preferred source order:
  - Prefer `connection.current_user` when present
  - Fall back to `warden.user(:user)` (the in-memory proxy)
  - Regression guard: `does not consult warden.session_serializer`
  - Clear `@current_user` when neither source reports a user

## Downstream follow-up
Wooftech will drop its custom `sync_current_user_from_warden!` and call this public helper instead, after this lands on master + gets released.

## Test plan
- [x] `bundle exec rspec spec/channels/api_maker/channel_spec.rb` — 6 examples, 0 failures
- [x] Verified the regression spec fails when the implementation is reverted to read from `session_serializer`
- [x] `bundle exec rubocop ruby-gem/app/channels/api_maker/channel.rb ruby-gem/spec/channels/api_maker/channel_spec.rb`