### PR TITLE
Add deselect-all action to table settings

### DIFF
--- a/npm-api-maker/src/table/settings/column-row.jsx
+++ b/npm-api-maker/src/table/settings/column-row.jsx
@@ -24,12 +24,12 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   })
 
   setup() {
-    this.checked = this.p.tableSettingColumn.visible()
     this.checkboxRef = useRef(undefined)
+    this.visible = this.p.tableSettingColumn.visible()
 
     useEffect(() => {
       this.updateCheckboxChecked()
-    }, [this.checked])
+    }, [this.visible])
   }
 
   render() {
@@ -56,27 +56,26 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   onCheckboxChange = () => {
-    const {checked} = this
+    const checked = this.p.tableSettingColumn.visible()
+    let visible
 
     if (checked === true) {
-      this.checked = null
+      visible = null
     } else if (checked === null) {
-      this.checked = false
+      visible = false
     } else {
-      this.checked = true
+      visible = true
     }
 
-    this.updateCheckboxChecked()
-    this.updateTableSettingColumn()
+    this.updateCheckboxChecked(visible)
+    this.updateTableSettingColumn(visible)
   }
 
-  updateCheckboxChecked() {
-    const {checked} = this.tt
-
-    if (checked === true) {
+  updateCheckboxChecked(visible = this.p.tableSettingColumn.visible()) {
+    if (visible === true) {
       this.checkboxRef.current.checked = true
       this.checkboxRef.current.indeterminate = undefined
-    } else if (checked === null) {
+    } else if (visible === null) {
       this.checkboxRef.current.checked = undefined
       this.checkboxRef.current.indeterminate = true
     } else {
@@ -85,10 +84,10 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     }
   }
 
-  async updateTableSettingColumn() {
+  async updateTableSettingColumn(visible) {
     const {table, tableSettingColumn} = this.p
 
-    await tableSettingColumn.update({visible: this.checked})
+    await tableSettingColumn.update({visible})
 
     table.events.emit("columnVisibilityUpdated", {tableSettingColumn})
   }

--- a/npm-api-maker/src/table/settings/index.jsx
+++ b/npm-api-maker/src/table/settings/index.jsx
@@ -9,7 +9,7 @@ import Modal from "../../modal"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
-import {View} from "react-native"
+import {Pressable, View} from "react-native"
 import Text from "../../utils/text"
 import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
 
@@ -63,11 +63,34 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
               {t(".columns", {defaultValue: "Columns"})}
             </Text>
           </View>
+          <Pressable
+            dataSet={this.cache("deselectAllPressableDataSet", {component: "api-maker/table/settings/deselect-all-action"})}
+            onPress={this.tt.onDeselectAllPress}
+            style={this.cache("deselectAllPressableStyle", {marginBottom: 10})}
+            testID="table-settings-deselect-all-button"
+          >
+            <Text>
+              {t(".deselect_all", {defaultValue: "Deselect all"})}
+            </Text>
+          </Pressable>
           {preparedColumns?.map(({column, tableSettingColumn}) =>
             <ColumnRow column={column} key={columnIdentifier(column)} table={table} tableSettingColumn={tableSettingColumn} />
           )}
         </View>
       </Modal>
     )
+  }
+
+  onDeselectAllPress = async () => {
+    const {table} = this.p
+    const {preparedColumns} = table.s
+
+    await Promise.all(
+      preparedColumns.map(async ({tableSettingColumn}) => {
+        await tableSettingColumn.update({visible: false})
+      })
+    )
+
+    table.events.emit("columnVisibilityUpdated")
   }
 }))

--- a/npm-api-maker/src/table/settings/index.jsx
+++ b/npm-api-maker/src/table/settings/index.jsx
@@ -85,6 +85,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     const {table} = this.p
     const {preparedColumns} = table.s
 
+    if (!preparedColumns) return
+
     await Promise.all(
       preparedColumns.map(async ({tableSettingColumn}) => {
         await tableSettingColumn.update({visible: false})

--- a/ruby-gem/spec/system/api_maker_table/settings_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/settings_spec.rb
@@ -71,5 +71,8 @@ describe "table - settings" do
     wait_for_no_selector "[data-class='table--column'][data-identifier='attribute-name--sort-key-name']"
     wait_for_no_selector "[data-class='table--column'][data-identifier='project--attribute-name--sort-key-projectName']"
     wait_for_no_selector "[data-class='table--column'][data-identifier='attribute-createdAt--sort-key-createdAt']"
+
+    wait_for_and_find(".api-maker--table--setings--column-checkbox[data-identifier='attribute-id--sort-key-id']").click
+    wait_for_selector "[data-class='table--column'][data-identifier='attribute-id--sort-key-id']"
   end
 end

--- a/ruby-gem/spec/system/api_maker_table/settings_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/settings_spec.rb
@@ -49,4 +49,27 @@ describe "table - settings" do
     sleep 1
     expect_no_errors
   end
+
+  it "de-selects all columns" do
+    task1
+    task2
+
+    login_as user_admin
+    visit bootstrap_live_table_path
+    wait_for_selector model_row_selector(task1)
+    wait_for_selector model_row_selector(task2)
+    wait_for_selector "[data-class='table--column'][data-identifier='attribute-id--sort-key-id']"
+    wait_for_selector "[data-class='table--column'][data-identifier='attribute-name--sort-key-name']"
+    wait_for_selector "[data-class='table--column'][data-identifier='project--attribute-name--sort-key-projectName']"
+    wait_for_selector "[data-class='table--column'][data-identifier='attribute-createdAt--sort-key-createdAt']"
+
+    wait_for_and_find("[data-testid='settings-button']").click
+    wait_for_selector "[data-class='api-maker--table--settings']"
+    wait_for_and_find("[data-testid='table-settings-deselect-all-button']").click
+
+    wait_for_no_selector "[data-class='table--column'][data-identifier='attribute-id--sort-key-id']"
+    wait_for_no_selector "[data-class='table--column'][data-identifier='attribute-name--sort-key-name']"
+    wait_for_no_selector "[data-class='table--column'][data-identifier='project--attribute-name--sort-key-projectName']"
+    wait_for_no_selector "[data-class='table--column'][data-identifier='attribute-createdAt--sort-key-createdAt']"
+  end
 end


### PR DESCRIPTION
## Summary
- add a table settings action to hide every column at once
- emit the existing column visibility update event after the bulk update
- cover the new action with a system spec

## Validation
- cd npm-api-maker && npm run lint:eslint -- src/table/settings/index.jsx
- cd npm-api-maker && npm run typecheck:file -- --file=src/table/settings/index.jsx
- cd ruby-gem && bundle exec rubocop spec/system/api_maker_table/settings_spec.rb
- cd npm-api-maker && npm run build
- cd ruby-gem && scripts/run-system-spec.sh spec/system/api_maker_table/settings_spec.rb
