### PR TITLE
Coarse workplace-link broadcasts + frontend refetch

### DIFF
--- a/api_maker_table_rubygem/app/api_maker/commands/workplaces/add_query.rb
+++ b/api_maker_table_rubygem/app/api_maker/commands/workplaces/add_query.rb
@@ -2,12 +2,8 @@ class Commands::Workplaces::AddQuery < Commands::ApplicationCommand
   alias workplace model
 
   def execute!
-    result = WorkerPlugins::AddQuery.execute!(
-      query: query,
-      workplace: workplace
-    )
-    created = result.fetch(:created)
-    workplace.api_maker_event("workplace_links_created", created: {model_class.name => created})
+    WorkerPlugins::AddQuery.execute!(query: query, workplace: workplace)
+    workplace.api_maker_event("workplace_links_created", resource_types: [model_class.name])
     succeed!(success: true)
   end
 

--- a/api_maker_table_rubygem/app/api_maker/commands/workplaces/create_link.rb
+++ b/api_maker_table_rubygem/app/api_maker/commands/workplaces/create_link.rb
@@ -6,7 +6,7 @@ class Commands::Workplaces::CreateLink < Commands::ApplicationCommand
 
     if model
       current_workplace.workplace_links.create(resource: model)
-      current_workplace.api_maker_event("workplace_links_created", created: {model_class => [model_id]})
+      current_workplace.api_maker_event("workplace_links_created", resource_types: [model_class])
       succeed!(success: true)
     else
       fail!(errors: ["Model not found or not accessible"])

--- a/api_maker_table_rubygem/app/api_maker/commands/workplaces/delete_all_links.rb
+++ b/api_maker_table_rubygem/app/api_maker/commands/workplaces/delete_all_links.rb
@@ -2,19 +2,14 @@ class Commands::Workplaces::DeleteAllLinks < Commands::ApplicationCommand
   alias workplace model
 
   def execute!
-    workplace_links = workplace
+    model_type = args.fetch(:model_type)
+
+    workplace
       .workplace_links
-      .where(resource_type: args.fetch(:model_type))
-      .select(:resource_id, :resource_type)
+      .where(resource_type: model_type)
+      .delete_all
 
-    destroyed = {}
-    workplace_links.each do |workplace_link|
-      destroyed[workplace_link.resource_type] ||= []
-      destroyed[workplace_link.resource_type] << workplace_link.resource_id
-    end
-
-    workplace_links.delete_all
-    current_workplace.api_maker_event("workplace_links_destroyed", destroyed: destroyed)
+    current_workplace.api_maker_event("workplace_links_destroyed", resource_types: [model_type])
     succeed!(success: true)
   end
 end

--- a/api_maker_table_rubygem/app/api_maker/commands/workplaces/destroy_links.rb
+++ b/api_maker_table_rubygem/app/api_maker/commands/workplaces/destroy_links.rb
@@ -1,6 +1,6 @@
 class Commands::Workplaces::DestroyLinks < Commands::ApplicationCommand
   def execute!
-    destroyed = {}
+    resource_types = []
 
     args.fetch(:models).each do |model_name, ids|
       # Convert from string to integer. API maker stringifies all arguments because of FormData usage
@@ -9,10 +9,10 @@ class Commands::Workplaces::DestroyLinks < Commands::ApplicationCommand
       model_class_name = resource.model_class.name
 
       current_workplace.workplace_links.where(resource_id: ids, resource_type: model_class_name).delete_all
-      destroyed[model_name] ||= ids
+      resource_types << model_class_name
     end
 
-    current_workplace.api_maker_event("workplace_links_destroyed", destroyed: destroyed)
+    current_workplace.api_maker_event("workplace_links_destroyed", resource_types: resource_types.uniq)
     succeed!(success: true)
   end
 end

--- a/api_maker_table_rubygem/app/api_maker/commands/workplaces/remove_query.rb
+++ b/api_maker_table_rubygem/app/api_maker/commands/workplaces/remove_query.rb
@@ -2,12 +2,8 @@ class Commands::Workplaces::RemoveQuery < Commands::ApplicationCommand
   alias workplace model
 
   def execute!
-    result = WorkerPlugins::RemoveQuery.execute!(
-      query: query,
-      workplace: workplace
-    )
-    destroyed = result.fetch(:destroyed)
-    workplace.api_maker_event("workplace_links_destroyed", destroyed: {model_class.name => destroyed})
+    WorkerPlugins::RemoveQuery.execute!(query: query, workplace: workplace)
+    workplace.api_maker_event("workplace_links_destroyed", resource_types: [model_class.name])
     succeed!(success: true)
   end
 

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -302,6 +302,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   draggableSortEvents = new EventEmitter()
   events = new EventEmitter()
   currentWorkplaceLoadRequestId = 0
+  currentWorkplaceCountRequestId = 0
   tableSettingLoadRequestId = 0
   tableSettings = null
   state = {
@@ -458,6 +459,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   async loadCurrentWorkplaceCount() {
+    const requestId = ++this.currentWorkplaceCountRequestId
+
     if (!this.s.currentWorkplace) {
       this.setState({currentWorkplaceCount: 0})
       return
@@ -470,6 +473,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
         workplace_id_eq: this.s.currentWorkplace.id()
       })
       .count()
+
+    if (requestId !== this.currentWorkplaceCountRequestId) return
 
     this.setState({currentWorkplaceCount})
   }

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -843,26 +843,14 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   onLinksCreated = ({args}) => {
-    const modelClassName = this.p.modelClass.modelClassData().name
-
-    if (args.created[modelClassName]) {
-      const amountCreated = args.created[modelClassName].length
-
-      this.setState((prevState) => ({
-        currentWorkplaceCount: prevState.currentWorkplaceCount + amountCreated
-      }))
+    if (args.resource_types?.includes(this.p.modelClass.modelClassData().name)) {
+      this.loadCurrentWorkplaceCount()
     }
   }
 
   onLinksDestroyed = ({args}) => {
-    const modelClassName = this.p.modelClass.modelClassData().name
-
-    if (args.destroyed[modelClassName]) {
-      const amountDestroyed = args.destroyed[modelClassName].length
-
-      this.setState((prevState) => ({
-        currentWorkplaceCount: prevState.currentWorkplaceCount - amountDestroyed
-      }))
+    if (args.resource_types?.includes(this.p.modelClass.modelClassData().name)) {
+      this.loadCurrentWorkplaceCount()
     }
   }
 

--- a/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
@@ -57,6 +57,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     indeterminate: false
   }
 
+  updateAllCheckedRequestId = 0
+
   setup() {
     useMemo(() => {
       this.updateAllChecked()
@@ -76,8 +78,12 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   async updateAllChecked() {
+    const requestId = ++this.updateAllCheckedRequestId
     const {query, currentWorkplace} = this.props
     const queryLinksStatusResult = await currentWorkplace.queryLinksStatus({query})
+
+    if (requestId !== this.updateAllCheckedRequestId) return
+
     const allChecked = queryLinksStatusResult.all_checked
     const someChecked = queryLinksStatusResult.some_checked
 

--- a/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
@@ -120,13 +120,13 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   onLinksCreated = ({args}) => {
-    if (args.created[this.modelClassName()]) {
+    if (args.resource_types?.includes(this.modelClassName())) {
       this.updateAllChecked()
     }
   }
 
   onLinksDestroyed = ({args}) => {
-    if (args.destroyed[this.modelClassName()]) {
+    if (args.resource_types?.includes(this.modelClassName())) {
       this.updateAllChecked()
     }
   }

--- a/npm-api-maker/src/table/worker-plugins-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-checkbox.jsx
@@ -90,22 +90,14 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   onLinksCreated = ({args}) => {
-    const {model} = this.p
-    const id = model.id()
-    const modelClassName = model.modelClassData().name
-
-    if (args.created[modelClassName] && args.created[modelClassName].includes(id)) {
-      this.setState({checked: true})
+    if (args.resource_types?.includes(this.p.model.modelClassData().name)) {
+      this.loadCurrentLink()
     }
   }
 
   onLinksDestroyed = ({args}) => {
-    const {model} = this.p
-    const id = model.id()
-    const modelClassName = model.modelClassData().name
-
-    if (args.destroyed[modelClassName] && args.destroyed[modelClassName].includes(id)) {
-      this.setState({checked: false})
+    if (args.resource_types?.includes(this.p.model.modelClassData().name)) {
+      this.loadCurrentLink()
     }
   }
 }))

--- a/npm-api-maker/src/table/worker-plugins-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-checkbox.jsx
@@ -30,6 +30,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     linkLoaded: false
   }
 
+  loadCurrentLinkRequestId = 0
+
   setup() {
     useMemo(() => {
       this.loadCurrentLink()
@@ -40,8 +42,12 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   async loadCurrentLink() {
+    const requestId = ++this.loadCurrentLinkRequestId
     const {model} = this.props
     const response = await Workplace.linkFor({model_class: model.modelClassData().name, model_id: model.id()})
+
+    if (requestId !== this.loadCurrentLinkRequestId) return
+
     const link = digg(response, "link")
 
     this.setState({


### PR DESCRIPTION
## Summary
Previously every \`workplace_links_created\` / \`workplace_links_destroyed\` event carried \`{created: {ModelName => [ids]}}\` (or \`{destroyed: ...}\`). On large workplaces this forced the backend to materialize hundreds of thousands of resource ids per call — tens of megabytes of Ruby string allocations per click — just so the three frontend listeners could filter out the handful they were rendering.

**Backend (\`api_maker_table_rubygem\`)** — six workplace commands (\`add_query\`, \`remove_query\`, \`create_link\`, \`destroy_links\`, \`delete_all_links\`) broadcast a coarse \`{resource_types: [ModelName, ...]}\` payload. No id lists travel over the wire.

**Frontend (\`npm-api-maker\`)** — the three listeners (\`worker-plugins-checkbox\`, \`worker-plugins-check-all-checkbox\`, \`table.jsx\`) now check whether their model class is in \`args.resource_types\` and refetch whatever they were displaying (\`loadCurrentLink\` / \`updateAllChecked\` / \`loadCurrentWorkplaceCount\`) instead of patching state from the id list.

## Dependency
- Requires \`worker_plugins\` from PR https://github.com/kaspernj/worker_plugins/pull/352 which drops id plucking from \`AddQuery\` / \`RemoveQuery\` / \`SwitchQuery\`. Consumers that call those services and rely on \`result.fetch(:created)\` / \`result.fetch(:destroyed)\` must migrate to \`result.fetch(:affected_count)\`.

## Test plan
- [x] Ruby syntax check on all five changed commands.
- [x] \`npm run typecheck\` clean.
- [x] ESLint clean on the three changed JSX files.
- [ ] Manual smoke test of \"Add selected\" / \"Remove selected\" flows on wooftech's admin/users page with a \`path:\`-linked \`api_maker_table\` + \`npm-api-maker\` against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)