### PR TITLE
Block table UI during heavy workplace actions

### DIFF
--- a/npm-api-maker/src/table/blocking-overlay.jsx
+++ b/npm-api-maker/src/table/blocking-overlay.jsx
@@ -1,0 +1,84 @@
+// @ts-check
+/* eslint-disable sort-imports */
+import React, {useRef} from "react"
+import memo from "set-state-compare/build/memo.js"
+import PropTypes from "prop-types"
+import propTypesExact from "prop-types-exact"
+import {ActivityIndicator, Animated} from "react-native"
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
+import useEventEmitter from "ya-use-event-emitter"
+
+const FADE_DURATION = 150
+
+/**
+ * @typedef {object} Props
+ * @property {import("events").EventEmitter} events
+ */
+/**
+ * @typedef {object} State
+ * @property {boolean} visible
+ */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableBlockingOverlay extends ShapeComponent {
+  static propTypes = propTypesExact({
+    events: PropTypes.object.isRequired
+  })
+
+  state = {visible: false}
+
+  animationSequence = 0
+
+  setup() {
+    this.opacity = useRef(new Animated.Value(0)).current
+
+    useEventEmitter(this.p.events, "blocking", this.tt.onBlocking)
+  }
+
+  render() {
+    if (!this.s.visible) return null
+
+    return (
+      <Animated.View
+        dataSet={this.cache("overlayDataSet", {class: "api-maker--table--blocking-overlay"})}
+        pointerEvents="auto"
+        style={this.cache("overlayStyle", {
+          position: "absolute",
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          backgroundColor: "rgba(64, 64, 64, 0.5)",
+          alignItems: "center",
+          justifyContent: "center",
+          zIndex: 10,
+          opacity: this.opacity
+        })}
+        testID="api-maker/table/blocking-overlay"
+      >
+        <ActivityIndicator color="#fff" size="large" />
+      </Animated.View>
+    )
+  }
+
+  onBlocking = (blocking) => {
+    const sequence = ++this.animationSequence
+
+    if (blocking) {
+      this.setState({visible: true})
+      Animated.timing(this.opacity, {
+        duration: FADE_DURATION,
+        toValue: 1,
+        useNativeDriver: false
+      }).start()
+    } else {
+      Animated.timing(this.opacity, {
+        duration: FADE_DURATION,
+        toValue: 0,
+        useNativeDriver: false
+      }).start(({finished}) => {
+        if (finished && sequence === this.animationSequence) {
+          this.setState({visible: false})
+        }
+      })
+    }
+  }
+}))

--- a/npm-api-maker/src/table/model-row.jsx
+++ b/npm-api-maker/src/table/model-row.jsx
@@ -141,7 +141,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
   onDestroyClicked = async () => {
     const {t} = this.tt
-    const {destroyMessage} = this.p.table.props
+    const {table} = this.p
+    const {destroyMessage} = table.props
     const {model} = this.p
 
     // eslint-disable-next-line no-alert
@@ -150,7 +151,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     }
 
     try {
-      await model.destroy()
+      await table.withBlocking(() => model.destroy())
 
       if (destroyMessage) {
         FlashNotifications.success(destroyMessage)

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -6,6 +6,7 @@
 import {dig, digg, digs} from "diggerize"
 import React, {createContext, useContext, useEffect, useMemo, useRef} from "react"
 import {Animated, Platform, Pressable, View} from "react-native"
+import BlockingOverlay from "./blocking-overlay"
 import Card from "../bootstrap/card"
 import classNames from "classnames"
 import Collection from "../collection.js"
@@ -149,6 +150,7 @@ const ListHeaderComponent = memo(shapeComponent(/** @augments {ShapeComponent<He
               currentWorkplace={table.s.currentWorkplace}
               query={queryWithoutPagination}
               style={styles.workerPlguinsCheckAllCheckboxStyle ||= {marginHorizontal: "auto"}}
+              table={table}
             />
             {!mdUp &&
               <Text style={styles.selectAllFoundTextStyle ||= {marginLeft: 3}}>
@@ -305,6 +307,31 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   currentWorkplaceCountRequestId = 0
   tableSettingLoadRequestId = 0
   tableSettings = null
+  blockingCount = 0
+
+  /**
+   * Runs the given async function while showing the table's blocking overlay,
+   * preventing the user from starting a second heavy action (select all,
+   * deselect all, per-row destroy, ...) while the first is in flight.
+   *
+   * Re-entrant — nested or overlapping calls keep the overlay shown until the
+   * outermost call resolves.
+   *
+   * @template T
+   * @param {() => Promise<T>} fn
+   * @returns {Promise<T>}
+   */
+  withBlocking = async (fn) => {
+    this.blockingCount += 1
+    if (this.blockingCount === 1) this.events.emit("blocking", true)
+
+    try {
+      return await fn()
+    } finally {
+      this.blockingCount -= 1
+      if (this.blockingCount === 0) this.events.emit("blocking", false)
+    }
+  }
   state = {
     columns: this.columnsAsArray(),
     currentWorkplace: undefined,
@@ -778,25 +805,31 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
     const flatList = (
       <TableContext.Provider value={this.tt.tableContextValue}>
-        <FlatList
-          data={models}
-          dataSet={dataSets[`flatList-${className}-${this.s.tableSettingFullCacheKey}`] ||= {
-            class: classNames("api-maker--table", className),
-            cacheKey: this.s.tableSettingFullCacheKey,
-            lastUpdate: this.s.lastUpdate
-          }}
-          extraData={this.s.lastUpdate}
-          keyExtractor={this.tt.keyExtrator}
-          ListHeaderComponent={ListHeaderComponent}
-          renderItem={this.tt.renderItem}
-          showsHorizontalScrollIndicator
-          style={styles[`flatList-${styleUI}`] ||= {
-            overflowX: "auto",
-            border: styleUI ? "1px solid #dbdbdb" : undefined,
-            borderRadius: styleUI ? 5 : undefined
-          }}
-          {...restProps}
-        />
+        <View
+          dataSet={dataSets.flatListWrapper ||= {class: "api-maker--table--flat-list-wrapper"}}
+          style={styles.flatListWrapper ||= {position: "relative"}}
+        >
+          <FlatList
+            data={models}
+            dataSet={dataSets[`flatList-${className}-${this.s.tableSettingFullCacheKey}`] ||= {
+              class: classNames("api-maker--table", className),
+              cacheKey: this.s.tableSettingFullCacheKey,
+              lastUpdate: this.s.lastUpdate
+            }}
+            extraData={this.s.lastUpdate}
+            keyExtractor={this.tt.keyExtrator}
+            ListHeaderComponent={ListHeaderComponent}
+            renderItem={this.tt.renderItem}
+            showsHorizontalScrollIndicator
+            style={styles[`flatList-${styleUI}`] ||= {
+              overflowX: "auto",
+              border: styleUI ? "1px solid #dbdbdb" : undefined,
+              borderRadius: styleUI ? 5 : undefined
+            }}
+            {...restProps}
+          />
+          <BlockingOverlay events={this.events} />
+        </View>
       </TableContext.Provider>
     )
 

--- a/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
@@ -39,6 +39,7 @@ const Checkbox = memo(shapeComponent(/** @augments {ShapeComponent<CheckboxProps
  * @property {object} [currentWorkplace]
  * @property {Collection} [query]
  * @property {object} [style]
+ * @property {object} [table]
  */
 /**
  * @typedef {object} State
@@ -49,7 +50,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   static propTypes = propTypesExact({
     currentWorkplace: PropTypes.object,
     query: PropTypes.instanceOf(Collection),
-    style: PropTypes.object
+    style: PropTypes.object,
+    table: PropTypes.object
   })
 
   state = {
@@ -113,14 +115,15 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   onCheckedChanged = async (e) => {
     e.preventDefault()
 
-    const {currentWorkplace, query} = this.props
+    const {currentWorkplace, query, table} = this.props
     const checkbox = e.target
+    const run = table?.withBlocking ?? ((fn) => fn())
 
     if (checkbox.checked) {
-      await currentWorkplace.addQuery({query})
+      await run(() => currentWorkplace.addQuery({query}))
       this.setState({checked: true, indeterminate: false})
     } else {
-      await currentWorkplace.removeQuery({query})
+      await run(() => currentWorkplace.removeQuery({query}))
       this.setState({checked: false, indeterminate: false})
     }
   }


### PR DESCRIPTION
## Summary
Select-all / deselect-all / per-row destroy all kick off round-trips that can take a while on large tables. Without a visible UI block the user thinks their click didn't register and fires a second one, which doubles the load. This PR adds a grey overlay with a centered \`ActivityIndicator\` over the table's FlatList that fades in / out via \`react-native\` \`Animated\` while the table is busy.

## Design

- New \`src/table/blocking-overlay.jsx\` — a \`ShapeComponent\` that listens for \`\"blocking\"\` events on the table's emitter and drives an \`Animated.Value\` opacity (0 → 1 over 150 ms, and back). Uses an animation-sequence counter so a rapid block → unblock → block sequence doesn't flicker off mid-fade.
- New \`table.withBlocking(asyncFn)\` helper (on the table component itself). Re-entrant — nested or overlapping calls keep the overlay shown until the outermost resolves. Emits \`(\"blocking\", true)\` on the first call and \`(\"blocking\", false)\` when the last in-flight call resolves.
- The overlay is rendered in a positioned wrapper \`<View>\` around the \`FlatList\` inside \`cardOrTable()\`, so it covers only the data area.

## Call sites wired

- \`worker-plugins-check-all-checkbox.jsx\` — \`addQuery\` / \`removeQuery\` on the header select-all toggle.
- \`model-row.jsx\` — per-row destroy button.

## Test plan

- [x] \`npm run lint\` — clean.
- [x] \`npm run typecheck\` — clean.
- [ ] Manual: check-all toggle on a large collection (341k users) shows overlay during the round-trip and clears it when the re-fetch lands; per-row destroy briefly flashes the overlay; rapid double-clicks on the select-all toggle stay blocked until the whole sequence resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)