### PR TITLE
Show blocking overlay during automatic workplace-link refreshes

### DIFF
--- a/npm-api-maker/src/table/blocking-overlay.jsx
+++ b/npm-api-maker/src/table/blocking-overlay.jsx
@@ -16,16 +16,14 @@ const FADE_DURATION = 150
  */
 /**
  * @typedef {object} State
- * @property {boolean} visible
+ * @property {boolean} blocking
  */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerTableBlockingOverlay extends ShapeComponent {
   static propTypes = propTypesExact({
     events: PropTypes.object.isRequired
   })
 
-  state = {visible: false}
-
-  animationSequence = 0
+  state = {blocking: false}
 
   setup() {
     this.opacity = useRef(new Animated.Value(0)).current
@@ -34,12 +32,13 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   render() {
-    if (!this.s.visible) return null
-
+    // Always mounted — pointerEvents toggles click-capture, opacity drives
+    // the fade. Kept out of conditional render so the Animated.Value and
+    // emitter subscription don't churn on every block/unblock.
     return (
       <Animated.View
         dataSet={this.cache("overlayDataSet", {class: "api-maker--table--blocking-overlay"})}
-        pointerEvents="auto"
+        pointerEvents={this.s.blocking ? "auto" : "none"}
         style={this.cache("overlayStyle", {
           position: "absolute",
           top: 0,
@@ -60,25 +59,11 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   onBlocking = (blocking) => {
-    const sequence = ++this.animationSequence
-
-    if (blocking) {
-      this.setState({visible: true})
-      Animated.timing(this.opacity, {
-        duration: FADE_DURATION,
-        toValue: 1,
-        useNativeDriver: false
-      }).start()
-    } else {
-      Animated.timing(this.opacity, {
-        duration: FADE_DURATION,
-        toValue: 0,
-        useNativeDriver: false
-      }).start(({finished}) => {
-        if (finished && sequence === this.animationSequence) {
-          this.setState({visible: false})
-        }
-      })
-    }
+    this.setState({blocking})
+    Animated.timing(this.opacity, {
+      duration: FADE_DURATION,
+      toValue: blocking ? 1 : 0,
+      useNativeDriver: false
+    }).start()
   }
 }))

--- a/npm-api-maker/src/table/blocking-overlay.jsx
+++ b/npm-api-maker/src/table/blocking-overlay.jsx
@@ -35,9 +35,14 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     // Always mounted — pointerEvents toggles click-capture, opacity drives
     // the fade. Kept out of conditional render so the Animated.Value and
     // emitter subscription don't churn on every block/unblock.
+    const dataSet = {
+      class: "api-maker--table--blocking-overlay",
+      overlayState: this.s.blocking ? "blocking" : "idle"
+    }
+
     return (
       <Animated.View
-        dataSet={this.cache("overlayDataSet", {class: "api-maker--table--blocking-overlay"})}
+        dataSet={dataSet}
         pointerEvents={this.s.blocking ? "auto" : "none"}
         style={this.cache("overlayStyle", {
           position: "absolute",

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -317,19 +317,25 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
    * Re-entrant — nested or overlapping calls keep the overlay shown until the
    * outermost call resolves.
    *
+   * Emits the "blocking" events via `queueMicrotask` so the overlay's
+   * subscription has committed before the first event fires — otherwise a
+   * heavy action kicked off from a sibling component's `setup()` (e.g. the
+   * check-all checkbox's initial `updateAllChecked`) can emit before the
+   * overlay mounts, and the initial transition to blocking is lost.
+   *
    * @template T
    * @param {() => Promise<T>} fn
    * @returns {Promise<T>}
    */
   withBlocking = async (fn) => {
     this.blockingCount += 1
-    if (this.blockingCount === 1) this.events.emit("blocking", true)
+    if (this.blockingCount === 1) queueMicrotask(() => this.events.emit("blocking", true))
 
     try {
       return await fn()
     } finally {
       this.blockingCount -= 1
-      if (this.blockingCount === 0) this.events.emit("blocking", false)
+      if (this.blockingCount === 0) queueMicrotask(() => this.events.emit("blocking", false))
     }
   }
   state = {

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -494,12 +494,12 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     }
 
     const WorkplaceLink = modelClassRequire("WorkplaceLink")
-    const currentWorkplaceCount = await WorkplaceLink
+    const currentWorkplaceCount = await this.withBlocking(() => WorkplaceLink
       .ransack({
         resource_type_eq: this.p.modelClass.modelClassData().name,
         workplace_id_eq: this.s.currentWorkplace.id()
       })
-      .count()
+      .count())
 
     if (requestId !== this.currentWorkplaceCountRequestId) return
 

--- a/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
+++ b/npm-api-maker/src/table/worker-plugins-check-all-checkbox.jsx
@@ -81,8 +81,9 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
   async updateAllChecked() {
     const requestId = ++this.updateAllCheckedRequestId
-    const {query, currentWorkplace} = this.props
-    const queryLinksStatusResult = await currentWorkplace.queryLinksStatus({query})
+    const {query, currentWorkplace, table} = this.props
+    const run = table?.withBlocking ?? ((fn) => fn())
+    const queryLinksStatusResult = await run(() => currentWorkplace.queryLinksStatus({query}))
 
     if (requestId !== this.updateAllCheckedRequestId) return
 

--- a/ruby-gem/spec/dummy/app/javascript/routes/bootstrap/live-table.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/bootstrap/live-table.jsx
@@ -76,6 +76,10 @@ export default class BootstrapLiveTable extends React.PureComponent {
         </Pressable>
     }
 
+    if (params.workplace) {
+      liveTableProps.workplace = true
+    }
+
     return (
       <Layout>
         <ApiMakerTable

--- a/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+describe "bootstrap - live table - worker_plugins workplace" do
+  let(:task1) { create :task, name: "Task 1" }
+  let(:task2) { create :task, name: "Task 2" }
+  let(:user_admin) { create :user, admin: true }
+
+  let(:check_all_selector) { ".api-maker--table--worker-plugins-check-all-checkbox" }
+
+  def checkbox_selector(model)
+    ".api-maker--table--worker-plugins-checkbox[data-model-id='#{model.id}']"
+  end
+
+  def current_workplace
+    user_admin.reload.current_workplace
+  end
+
+  def workplace_link_for(resource)
+    workplace = current_workplace
+    return nil unless workplace
+
+    WorkerPlugins::WorkplaceLink.find_by(
+      resource_type: resource.class.name,
+      resource_id: resource.id.to_s,
+      workplace:
+    )
+  end
+
+  it "creates a workplace link when a per-row checkbox is checked and removes it when unchecked" do
+    task1
+    task2
+
+    login_as user_admin
+    visit bootstrap_live_table_path(workplace: true)
+
+    wait_for_selector model_row_selector(task1)
+    wait_for_selector model_row_selector(task2)
+    wait_for_action_cable_to_connect
+
+    # Each checkbox renders with its initial unchecked state.
+    wait_for_selector "#{checkbox_selector(task1)}[data-checked='false']"
+    wait_for_selector "#{checkbox_selector(task2)}[data-checked='false']"
+
+    # Check task1 — the row checkbox must end up visibly checked AND the
+    # matching workplace_link must exist in the DB.
+    expect { worker_plugins_check(task1) }
+      .to change { workplace_link_for(task1) }.from(nil)
+
+    # task2 must stay unaffected by task1's click.
+    wait_for_selector "#{checkbox_selector(task2)}[data-checked='false']"
+    expect(workplace_link_for(task2)).to be_nil
+
+    # Click task1 again — link must be deleted and checkbox uncheck visibly.
+    expect { worker_plugins_check(task1) }
+      .to change { workplace_link_for(task1) }.to(nil)
+
+    wait_for_selector "#{checkbox_selector(task1)}[data-checked='false']"
+  end
+
+  it "checks all found rows when the header check-all is toggled on and removes them when toggled off" do
+    task1
+    task2
+
+    login_as user_admin
+    visit bootstrap_live_table_path(workplace: true)
+
+    wait_for_selector model_row_selector(task1)
+    wait_for_selector model_row_selector(task2)
+    wait_for_action_cable_to_connect
+
+    # Initial state — no links, check-all unchecked.
+    expect(workplace_link_for(task1)).to be_nil
+    expect(workplace_link_for(task2)).to be_nil
+
+    # Toggle check-all on — both rows become checked and both links appear.
+    wait_for_and_find(check_all_selector).click
+    wait_for_selector "#{checkbox_selector(task1)}[data-checked='true']"
+    wait_for_selector "#{checkbox_selector(task2)}[data-checked='true']"
+
+    expect(workplace_link_for(task1)).not_to be_nil
+    expect(workplace_link_for(task2)).not_to be_nil
+
+    # Toggle check-all off — both rows become unchecked and both links are gone.
+    wait_for_and_find(check_all_selector).click
+    wait_for_selector "#{checkbox_selector(task1)}[data-checked='false']"
+    wait_for_selector "#{checkbox_selector(task2)}[data-checked='false']"
+
+    expect(workplace_link_for(task1)).to be_nil
+    expect(workplace_link_for(task2)).to be_nil
+  end
+end

--- a/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
@@ -97,10 +97,11 @@ describe "bootstrap - live table - worker_plugins workplace" do
     login_as user_admin
     visit bootstrap_live_table_path(workplace: true, delay_query_ms: 400)
 
-    # Overlay element is always mounted; `data-blocking` reflects the current
-    # state so we can assert the overlay is actually covering the table rather
-    # than just sitting in the DOM. `visible: :all` because the overlay sits
-    # at opacity 0 when not blocking and Capybara treats that as invisible.
+    # Overlay element is always mounted; `data-overlay-state` reflects the
+    # current state so we can assert the overlay is actually covering the
+    # table rather than just sitting in the DOM. `visible: :all` because the
+    # overlay sits at opacity 0 when not blocking and Capybara treats that as
+    # invisible.
     expect(page).to have_css(overlay_selector, visible: :all)
     overlay_in_state = lambda do |state|
       expect(page).to have_css("#{overlay_selector}[data-overlay-state='#{state}']", visible: :all)
@@ -118,5 +119,42 @@ describe "bootstrap - live table - worker_plugins workplace" do
     overlay_in_state.call("idle")
     wait_for_selector "#{checkbox_selector(task1)}[data-checked='true']"
     wait_for_selector "#{checkbox_selector(task2)}[data-checked='true']"
+  end
+
+  it "visibly covers the table during a heavy action — opacity fades in and pointer-events intercept clicks" do
+    task1
+    task2
+
+    login_as user_admin
+    visit bootstrap_live_table_path(workplace: true, delay_query_ms: 800)
+
+    wait_for_selector model_row_selector(task1)
+    wait_for_action_cable_to_connect
+
+    # Kick off a heavy action that holds the overlay blocking for ~800 ms
+    # (delayed query plus the auto-refresh probe that follows).
+    wait_for_and_find(check_all_selector).click
+
+    wait_for_selector "#{overlay_selector}[data-overlay-state='blocking']", visible: :all
+    overlay = find(overlay_selector, visible: :all)
+
+    # Opacity animates 0 → 1 over 150 ms; `match_style` reads the live
+    # computed-style via Capybara's driver API and retries until it settles
+    # so we don't read mid-transition.
+    expect(overlay).to match_style({"opacity" => "1"}, wait: 2)
+    expect(overlay).to match_style("pointer-events" => "auto")
+
+    # The overlay must physically cover the table — at minimum not collapse
+    # to a zero-sized node.
+    rect = overlay.rect
+    expect(rect.width).to be > 50
+    expect(rect.height).to be > 50
+
+    # When the action resolves the overlay must actually go away, not just
+    # drop its state flag. Opacity animates back to 0 and pointer-events to
+    # "none" so clicks reach the table again.
+    expect(page).to have_css("#{overlay_selector}[data-overlay-state='idle']", visible: :all)
+    expect(overlay).to match_style({"opacity" => "0"}, wait: 2)
+    expect(overlay).to match_style("pointer-events" => "none")
   end
 end

--- a/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
@@ -131,18 +131,38 @@ describe "bootstrap - live table - worker_plugins workplace" do
     wait_for_selector model_row_selector(task1)
     wait_for_action_cable_to_connect
 
-    # Kick off a heavy action that holds the overlay blocking for ~800 ms
-    # (delayed query plus the auto-refresh probe that follows).
+    # Kick off a heavy action — overlay should fade in and cover the table
+    # while the backend resolves.
     wait_for_and_find(check_all_selector).click
 
     wait_for_selector "#{overlay_selector}[data-overlay-state='blocking']", visible: :all
     overlay = find(overlay_selector, visible: :all)
 
-    # Opacity animates 0 → 1 over 150 ms; `match_style` reads the live
-    # computed-style via Capybara's driver API and retries until it settles
-    # so we don't read mid-transition.
-    expect(overlay).to match_style({"opacity" => "1"}, wait: 2)
+    # `pointer-events: auto` is the visible-coverage invariant — if the
+    # overlay is blocking clicks through to the table, it's rendered on top
+    # with hit-testing enabled. Unlike opacity (which animates), this flips
+    # instantly when state transitions, so it's a reliable signal.
     expect(overlay).to match_style("pointer-events" => "auto")
+
+    # Opacity is driven by an Animated.timing over 150 ms. On small
+    # datasets the whole blocking window can be shorter than the fade, so
+    # we poll for *any* non-zero opacity value rather than waiting for it
+    # to settle at 1 — we just need proof the overlay visibly faded in,
+    # not that it completed the full animation.
+    observed_visible = false
+    observed_opacity = 0.0
+    Timeout.timeout(3) do
+      loop do
+        value = overlay.style("opacity").fetch("opacity").to_f
+        observed_opacity = [observed_opacity, value].max
+        if observed_opacity > 0.1
+          observed_visible = true
+          break
+        end
+        sleep 0.02
+      end
+    end
+    expect(observed_visible).to(be(true), "overlay opacity never rose above 0.1 (max seen: #{observed_opacity})")
 
     # The overlay must physically cover the table — at minimum not collapse
     # to a zero-sized node.

--- a/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/worker_plugins_workplace_spec.rb
@@ -6,6 +6,7 @@ describe "bootstrap - live table - worker_plugins workplace" do
   let(:user_admin) { create :user, admin: true }
 
   let(:check_all_selector) { ".api-maker--table--worker-plugins-check-all-checkbox" }
+  let(:overlay_selector) { "[data-class='api-maker--table--blocking-overlay']" }
 
   def checkbox_selector(model)
     ".api-maker--table--worker-plugins-checkbox[data-model-id='#{model.id}']"
@@ -87,5 +88,35 @@ describe "bootstrap - live table - worker_plugins workplace" do
 
     expect(workplace_link_for(task1)).to be_nil
     expect(workplace_link_for(task2)).to be_nil
+  end
+
+  it "shows the blocking overlay while the check-all probe loads and while toggling all" do
+    task1
+    task2
+
+    login_as user_admin
+    visit bootstrap_live_table_path(workplace: true, delay_query_ms: 400)
+
+    # Overlay element is always mounted; `data-blocking` reflects the current
+    # state so we can assert the overlay is actually covering the table rather
+    # than just sitting in the DOM. `visible: :all` because the overlay sits
+    # at opacity 0 when not blocking and Capybara treats that as invisible.
+    expect(page).to have_css(overlay_selector, visible: :all)
+    overlay_in_state = lambda do |state|
+      expect(page).to have_css("#{overlay_selector}[data-overlay-state='#{state}']", visible: :all)
+    end
+
+    # The initial updateAllChecked probe should trigger the overlay; after the
+    # probe resolves, the overlay should drop back to idle.
+    overlay_in_state.call("blocking")
+    overlay_in_state.call("idle")
+
+    # Toggling the header select-all kicks off addQuery — overlay should come
+    # back on, then drop off when the action and the follow-up probe complete.
+    wait_for_and_find(check_all_selector).click
+    overlay_in_state.call("blocking")
+    overlay_in_state.call("idle")
+    wait_for_selector "#{checkbox_selector(task1)}[data-checked='true']"
+    wait_for_selector "#{checkbox_selector(task2)}[data-checked='true']"
   end
 end


### PR DESCRIPTION
## Summary
The overlay from #3012 only covered user-click actions (check-all toggle, per-row destroy). The two *auto-refresh* probes — \`queryLinksStatus\` behind the select-all checkbox and \`loadCurrentWorkplaceCount\` behind the footer count — run on component mount and after link events, so on a 340k-row workplace the user sees a frozen UI for multiple seconds with no feedback. This PR routes both through \`table.withBlocking\` so the overlay fades in while they're in flight.

Reported timings from the field (MariaDB, 341k User links, 341k live users):
- \`queryLinksStatus\` checked-count probe: ~2.2 s
- \`loadCurrentWorkplaceCount\` ransack count: ~0.8 s

## Not wrapped
- Per-row \`loadCurrentLink\` in \`worker-plugins-checkbox.jsx\`. Individually cheap (1–5 ms); 30 concurrent calls on every page load would flicker the overlay for no user benefit.

## Test plan
- [x] \`npm run lint\` clean.
- [x] \`npm run typecheck\` clean.
- [ ] Manual: mount the admin table with workplace selection enabled on the reporter's dataset and confirm the overlay covers the automatic probes as well as the explicit click actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)