### PR TITLE
Reject falsy models in Devise.updateSession and Devise.signIn

### DIFF
--- a/npm-api-maker/__tests__/devise.test.js
+++ b/npm-api-maker/__tests__/devise.test.js
@@ -5,6 +5,8 @@ import Services from "../src/services.js"
 import SessionStatusUpdater from "../src/session-status-updater.js"
 import {jest} from "@jest/globals"
 
+const signInModel = {id: () => 1}
+
 describe("ApiMakerDevise", () => {
   afterEach(() => {
     jest.restoreAllMocks()
@@ -20,7 +22,7 @@ describe("ApiMakerDevise", () => {
     })
     const refreshAuthentication = jest.fn().mockResolvedValue(undefined)
     const sendRequest = jest.spyOn(Services.current(), "sendRequest")
-      .mockResolvedValueOnce({model: null})
+      .mockResolvedValueOnce({model: signInModel})
       .mockResolvedValueOnce({success: true})
     jest.spyOn(SessionStatusUpdater, "current").mockReturnValue({applyResult, sessionStatus, updateSessionStatus})
     jest.spyOn(CableConnectionPool, "current").mockReturnValue({refreshAuthentication})
@@ -55,7 +57,7 @@ describe("ApiMakerDevise", () => {
   it("signs in over HTTP and refreshes websocket auth in place", async() => {
     const sendRequest = jest.spyOn(Services.current(), "sendRequest")
       .mockResolvedValueOnce({
-        model: null,
+        model: signInModel,
         session_status: {
           csrf_token: "token-1",
           scopes: {user: {signed_in: true}},
@@ -153,7 +155,7 @@ describe("ApiMakerDevise", () => {
 
   it("loads session status over HTTP before refreshing websocket auth when sign-in does not return it inline", async() => {
     const sendRequest = jest.spyOn(Services.current(), "sendRequest")
-      .mockResolvedValueOnce({model: null})
+      .mockResolvedValueOnce({model: signInModel})
       .mockResolvedValueOnce({success: true})
     const applyResult = jest.fn()
     const sessionStatus = jest.fn().mockResolvedValue({
@@ -190,5 +192,16 @@ describe("ApiMakerDevise", () => {
       shadowSessionToken: "shadow-token-3",
       signedIn: true
     })
+  })
+
+  it("throws when updateSession is called with a falsy model instead of silently flipping to signed-out", () => {
+    expect(() => ApiMakerDevise.updateSession(null)).toThrow(/Devise\.updateSession .* falsy model for scope "user"/)
+    expect(() => ApiMakerDevise.updateSession(undefined, {scope: "admin_user"})).toThrow(/scope "admin_user"/)
+  })
+
+  it("throws when the sign-in response does not include a model", async() => {
+    jest.spyOn(Services.current(), "sendRequest").mockResolvedValueOnce({model: null})
+
+    await expect(ApiMakerDevise.signIn("teacher@example.com", "secret")).rejects.toThrow(/did not include a model/)
   })
 })

--- a/npm-api-maker/src/devise.js
+++ b/npm-api-maker/src/devise.js
@@ -119,7 +119,7 @@ export default class ApiMakerDevise {
    * @param {string} username
    * @param {string} password
    * @param {DeviseScopeArgs} args
-   * @returns {Promise<{model: import("./base-model.js").default | undefined, response: DeviseSignInResponse}>}
+   * @returns {Promise<{model: import("./base-model.js").default, response: DeviseSignInResponse}>}
    */
   static async signIn(username, password, args = {}) {
     if (!args.scope) args.scope = "user"
@@ -135,6 +135,10 @@ export default class ApiMakerDevise {
     let model = response.model
 
     if (Array.isArray(model)) model = model[0]
+
+    if (!model) {
+      throw new Error(`Devise.signIn: Devise::SignIn response for scope "${args.scope}" did not include a model`)
+    }
 
     await ApiMakerDevise.syncSessionStatusAndRefreshWebsocket({
       httpResponse: response,
@@ -181,11 +185,26 @@ export default class ApiMakerDevise {
 
   /**
    * Updates the locally cached current model for one scope.
-   * @param {DeviseCurrentScope} model
+   *
+   * Always requires a real model instance. Writing a falsy value here used to
+   * be a silent foot-gun: when a caller awaited a query that returned
+   * `undefined` (for example `Collection#first()` on an empty result) and
+   * passed the value through, the scope cache flipped to "signed out" without
+   * any indication, dropping the user back on the sign-in screen right after
+   * a successful sign-in. Use `Devise.setSignedOut({scope})` to sign out.
+   *
+   * @param {NonNullable<DeviseCurrentScope>} model
    * @param {DeviseScopeArgs} args
    */
   static updateSession(model, args = {}) {
     if (!args.scope) args.scope = "user"
+
+    if (!model) {
+      throw new Error(
+        `Devise.updateSession was called with a falsy model for scope "${args.scope}". ` +
+        "Use Devise.setSignedOut({scope}) to sign out instead."
+      )
+    }
 
     const camelizedScopeName = inflection.camelize(args.scope, true)
 


### PR DESCRIPTION
## Summary

While investigating a wooftech bug where users occasionally land back on the sign-in screen immediately after signing in, I traced every path that can flip `ApiMakerDevise.currents[scope]` to null. The most obvious foot-gun turned out to be `Devise.updateSession` itself: it accepts any value, so a caller that forwards the result of an upstream query (for example `Collection#first()`, which returns `undefined` on an empty collection) silently flips the provider to "signed out" right after a successful sign-in. No warning, no error, just a surprising jump back to the sign-in form.

This change makes `Devise.updateSession` throw if called with a falsy model, directing the caller to `Devise.setSignedOut({scope})` for the intentional signed-out path. The sign-in flow gets a matching guard so we also reject a missing `model` in the HTTP `Devise::SignIn` response instead of feeding `undefined` into `updateSession` ourselves.

## Why this is safe

- `updateSession` has two internal callers (`signIn` in this file, and `use-current-user-context.jsx` where it is already guarded behind `if (current)`). The `signIn` caller is updated to guard in the same change.
- External callers that wanted the "sign out" branch should have been calling `Devise.setSignedOut({scope})`; the new throw surfaces that at the call site with a clear message.
- Typedef on `signIn` return value tightens from `model: BaseModel | undefined` to `model: BaseModel`, reflecting that a falsy model is no longer reachable.

## Test plan
- [x] `__tests__/devise.test.js` — new cases cover `updateSession(null)` / `updateSession(undefined, {scope})` throwing and `signIn` throwing when the response omits `model`. Existing tests updated to pass a model object.
- [x] `npx tsc --noEmit` clean.
- [x] `eslint --max-warnings 0` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)