### PR TITLE
Fail loud when SessionShadowStore sees a per-process Rails.cache

### DIFF
--- a/ruby-gem/lib/api_maker/session_shadow_store.rb
+++ b/ruby-gem/lib/api_maker/session_shadow_store.rb
@@ -2,8 +2,16 @@ class ApiMaker::SessionShadowStore
   CACHE_KEY_PREFIX = "api-maker-session-shadow-store".freeze
   EXPIRES_IN = 12 * 60 * 60
   LOADED_SESSION_ID_ENV_KEY = "api_maker.session_shadow_store.loaded_session_id".freeze
+  # Cache stores that are either per-process or no-op, neither of which can
+  # carry the shadow session between the HTTP sign-in worker and the cable
+  # worker. We fail loud rather than appear to work and silently drop sign-ins.
+  UNSUPPORTED_CACHE_STORE_NAMES = %w[
+    ActiveSupport::Cache::MemoryStore
+    ActiveSupport::Cache::NullStore
+  ].freeze
 
   def self.load!(request:)
+    ensure_shared_cache_store!
     session_data = read(request:)
     return if session_data.nil?
 
@@ -12,6 +20,7 @@ class ApiMaker::SessionShadowStore
   end
 
   def self.persist!(request:)
+    ensure_shared_cache_store!
     session_ids_for_write(request:).each do |session_id|
       Rails.cache.write(cache_key(session_id), request.session.to_hash, expires_in: EXPIRES_IN)
     end
@@ -24,6 +33,47 @@ class ApiMaker::SessionShadowStore
     request.env[LOADED_SESSION_ID_ENV_KEY] = session_id
     Rails.cache.read(cache_key(session_id))
   end
+
+  # Raises if Rails.cache is a per-process / no-op store that can't carry
+  # shadow-session data between Puma workers. ApiMaker's Devise sign-in path
+  # writes the warden session through Rails.cache on an HTTP request and then
+  # reads it back from a cable request; with `:memory_store` the HTTP write
+  # lands in one worker's memory and the cable read lands in another worker
+  # that has never seen it, so sign-in silently fails and every subsequent
+  # ability check runs as anonymous.
+  #
+  # Called on every load!/persist! but short-circuits after the first check
+  # passes so it is cheap on the hot path.
+  def self.ensure_shared_cache_store!
+    return if @shared_cache_store_verified
+
+    cache_class_name = Rails.cache.class.name
+    if UNSUPPORTED_CACHE_STORE_NAMES.include?(cache_class_name)
+      raise ApiMaker::SessionShadowStore::UnsupportedCacheStoreError, <<~MSG
+        ApiMaker::SessionShadowStore requires a Rails.cache that is shared
+        across processes, but Rails.cache is #{cache_class_name}.
+
+        Under clustered Puma, HTTP sign-in writes the warden session to one
+        worker's cache while the ActionCable Devise::PersistSession command
+        reads from another worker's cache and finds nothing — the websocket
+        stays signed out and ability checks fall back to the anonymous ruleset,
+        so signed-in users appear to be missing permissions at random.
+
+        Use a shared store, e.g. `:file_store` for single-host development or
+        `:mem_cache_store` / `:redis_cache_store` / `:solid_cache_store` for
+        multi-process / multi-host deployments.
+      MSG
+    end
+
+    @shared_cache_store_verified = true
+  end
+
+  # Test-only helper for resetting the memoized check.
+  def self.reset_shared_cache_store_check!
+    @shared_cache_store_verified = nil
+  end
+
+  class UnsupportedCacheStoreError < StandardError; end
 
   def self.read_signed(request: nil, token:) # rubocop:disable Lint/UnusedMethodArgument
     session_id = session_id_from_signed_token(token:)

--- a/ruby-gem/spec/dummy/config/environments/development.rb
+++ b/ruby-gem/spec/dummy/config/environments/development.rb
@@ -16,17 +16,18 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
+  # ApiMaker::SessionShadowStore refuses :memory_store / :null_store because
+  # they cannot carry the shadow session between Puma workers. Use :file_store
+  # for the dummy app so the boot-time check passes.
+  config.cache_store = :file_store, Rails.root.join("tmp/cache")
+
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
-
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)

--- a/ruby-gem/spec/dummy/config/environments/test.rb
+++ b/ruby-gem/spec/dummy/config/environments/test.rb
@@ -22,6 +22,11 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
+  # ApiMaker::SessionShadowStore refuses :memory_store / :null_store since they
+  # cannot carry shadow-session data between Puma workers. :file_store is fine
+  # for test so the boot-time check passes.
+  config.cache_store = :file_store, Rails.root.join("tmp/cache")
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/ruby-gem/spec/lib/api_maker/session_shadow_store_spec.rb
+++ b/ruby-gem/spec/lib/api_maker/session_shadow_store_spec.rb
@@ -82,26 +82,26 @@ describe ApiMaker::SessionShadowStore do
 
   describe "unsupported cache stores" do
     it "raises when Rails.cache is a per-process memory store because shadow-session data cannot cross Puma workers" do
-      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      expect(Rails).to receive(:cache).at_least(:once).and_return(ActiveSupport::Cache::MemoryStore.new)
 
       expect { described_class.persist!(request:) }
         .to raise_error(ApiMaker::SessionShadowStore::UnsupportedCacheStoreError, /ActiveSupport::Cache::MemoryStore/)
     end
 
     it "raises when Rails.cache is a null store because nothing is actually persisted" do
-      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::NullStore.new)
+      expect(Rails).to receive(:cache).at_least(:once).and_return(ActiveSupport::Cache::NullStore.new)
 
       expect { described_class.load!(request:) }
         .to raise_error(ApiMaker::SessionShadowStore::UnsupportedCacheStoreError, /ActiveSupport::Cache::NullStore/)
     end
 
-    it "stops raising once a shared cache store becomes visible" do
-      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+    it "re-checks and passes after the memoized unsupported result is reset with a shared store in place" do
+      expect(Rails).to receive(:cache).at_least(:once).and_return(ActiveSupport::Cache::MemoryStore.new)
       expect { described_class.persist!(request:) }
         .to raise_error(ApiMaker::SessionShadowStore::UnsupportedCacheStoreError)
 
       described_class.reset_shared_cache_store_check!
-      allow(Rails).to receive(:cache).and_call_original
+      RSpec::Mocks.space.proxy_for(Rails).reset
 
       expect { described_class.persist!(request:) }.not_to raise_error
     end

--- a/ruby-gem/spec/lib/api_maker/session_shadow_store_spec.rb
+++ b/ruby-gem/spec/lib/api_maker/session_shadow_store_spec.rb
@@ -20,6 +20,7 @@ describe ApiMaker::SessionShadowStore do
 
   before do
     Rails.cache.clear
+    described_class.reset_shared_cache_store_check!
   end
 
   it "persists the current session data in the cache" do
@@ -77,5 +78,32 @@ describe ApiMaker::SessionShadowStore do
     expect(
       Rails.cache.read(described_class.cache_key("new-session-id"))
     ).to include("warden.user.user.key" => ["User", "123"])
+  end
+
+  describe "unsupported cache stores" do
+    it "raises when Rails.cache is a per-process memory store because shadow-session data cannot cross Puma workers" do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+
+      expect { described_class.persist!(request:) }
+        .to raise_error(ApiMaker::SessionShadowStore::UnsupportedCacheStoreError, /ActiveSupport::Cache::MemoryStore/)
+    end
+
+    it "raises when Rails.cache is a null store because nothing is actually persisted" do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::NullStore.new)
+
+      expect { described_class.load!(request:) }
+        .to raise_error(ApiMaker::SessionShadowStore::UnsupportedCacheStoreError, /ActiveSupport::Cache::NullStore/)
+    end
+
+    it "stops raising once a shared cache store becomes visible" do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      expect { described_class.persist!(request:) }
+        .to raise_error(ApiMaker::SessionShadowStore::UnsupportedCacheStoreError)
+
+      described_class.reset_shared_cache_store_check!
+      allow(Rails).to receive(:cache).and_call_original
+
+      expect { described_class.persist!(request:) }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
## Summary

ApiMaker's `SessionShadowStore` is the bridge between HTTP Devise sign-in and ActionCable. The HTTP request writes the warden session into `Rails.cache`, and the cable's `Devise::PersistSession` command reads it back via a signed session-id token to rehydrate `current_user` on the websocket.

That handoff only works if `Rails.cache` is shared across processes. With `:memory_store` or `:null_store`, it isn't:

- Under clustered Puma, the HTTP sign-in lands on worker A, which writes the warden keys into worker A's in-memory cache.
- The ActionCable connection lives on worker B, which reads its own empty cache and finds nothing.
- `Devise::PersistSession` silently falls through to `warden.logout` (no model could be identified).
- `CanCan::LoadAbilities` and every subsequent cable command then runs as anonymous, so signed-in admins see a dashboard with most menu items hidden.

Nothing in the log surfaces the cause — the cache read just returns nil, PersistSession calls `succeed!` with `signed_in: false`, and the JS considers it "normal". Chasing this from symptoms requires instrumenting the shadow cache hits directly.

This change adds a guard in `load!` / `persist!` that raises `ApiMaker::SessionShadowStore::UnsupportedCacheStoreError` the first time a per-process store is detected, with a message pointing to `:file_store`, `:mem_cache_store`, `:redis_cache_store`, or `:solid_cache_store` as the fix. The check memoizes after the first successful pass so it stays cheap on the hot path (called from every Rack request via the middleware).

The dummy app's dev and test envs previously used `:memory_store` / `:null_store`; they're flipped to `:file_store` so api_maker's own specs pass the check.

## Test plan
- [x] `spec/lib/api_maker/session_shadow_store_spec.rb` — new cases cover `:memory_store` raising, `:null_store` raising, and the check relaxing once a shared store is visible. All 7 examples pass.
- [x] `bundle exec rubocop` clean on touched files.
- [x] Rest of the non-system spec suite runs no worse than master (2 pre-existing failures that don't touch this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)