### PR TITLE
Add form support to utils checkbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Notes:
 - In ApiMaker table workplace helpers and commands, `current_user` may legitimately be `nil` for websocket/content-parser requests; return `nil`/empty results for current-workplace lookups instead of dereferencing the user.
 - Before adding fallback logic for hook/context timing, inspect the provider source first; do not assume first-render hydration gaps without source confirmation.
 - Do not add helper methods for simple values or expressions that are only used in one place; inline them at the usage site instead.
+- Cache JSX object-literal props such as `dataSet` and `pressableProps` with typed module-level cache maps (`dataSets.name ||= {...}`) instead of recreating objects in render.
 - Keep `testID` values unique within a rendered screen/component so selectors stay unambiguous.
 - In Selenium/spec helpers, do not assume a `testID` selector points at the editable control itself; React Native Web may put the `testID` on a wrapper, so descend to the real `input`/`textarea`/checkbox element before typing or clearing.
 - In JavaScript class method definitions, use `methodName(args)` (no space before parentheses).

--- a/npm-api-maker/changelog.d/20260506-utils-checkbox-form-support.md
+++ b/npm-api-maker/changelog.d/20260506-utils-checkbox-form-support.md
@@ -1,0 +1,1 @@
+Utils checkbox now initializes and updates ApiMaker FormInputs values when used with a name or model attribute.

--- a/npm-api-maker/src/utils/checkbox.jsx
+++ b/npm-api-maker/src/utils/checkbox.jsx
@@ -60,7 +60,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     const {inputProps, restProps: useInputRestProps, wrapperOpts} = useInput({props: this.props, wrapperOptions: {type: "checkbox"}})
     const form = useForm()
     const inputName = inputProps.name
-    const isChecked = this.calculateChecked()
+    const initialChecked = this.calculateChecked()
 
     this.form = form
     this.inputProps = inputProps
@@ -69,13 +69,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
     useEffect(() => {
       if (form && inputName) {
-        form.setValue(inputName, isChecked)
-      }
-    }, [form, inputName, isChecked])
-
-    useEffect(() => () => {
-      if (form && inputName) {
-        form.unsetValue(inputName)
+        form.setValue(inputName, initialChecked)
       }
     }, [form, inputName])
   }

--- a/npm-api-maker/src/utils/checkbox.jsx
+++ b/npm-api-maker/src/utils/checkbox.jsx
@@ -2,61 +2,103 @@
 /* eslint-disable prefer-object-spread, sort-imports */
 // @ts-expect-error CheckBox removed from react-native core in newer versions
 import {CheckBox, Pressable, View} from "react-native"
-import React, {useMemo} from "react"
+import React, {useEffect, useMemo} from "react"
 import memo from "set-state-compare/build/memo.js"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
 import Text from "./text"
+import {useForm} from "../form"
+import useInput from "../use-input.js"
 
 /**
  * @typedef {object} Props
+ * @property {string} [attribute]
  * @property {boolean} [checked]
  * @property {object} [dataSet]
  * @property {boolean} [defaultChecked]
-  * @property {string} [label]
-  * @property {Function} [onCheckedChange]
-  * @property {object} [style]
-  * @property {string} [testID]
+ * @property {string} [id]
+ * @property {object} [inputRef]
+ * @property {string} [label]
+ * @property {object} [model]
+ * @property {string} [name]
+ * @property {Function} [onCheckedChange]
+ * @property {object} [style]
+ * @property {string} [testID]
  */
 /**
  * @typedef {object} State
- * @property {boolean | undefined} checked
+ * @property {boolean} checked
  */
 export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} */ class ApiMakerUtilsCheckbox extends ShapeComponent {
   static defaultProps = {
     dataSet: null,
-    label: undefined,
     style: null,
     testID: undefined
   }
 
   static propTypes = propTypesExact({
+    attribute: PropTypes.string,
     checked: PropTypes.bool,
     dataSet: PropTypes.object,
     defaultChecked: PropTypes.bool,
+    id: PropTypes.string,
+    inputRef: PropTypes.object,
     label: PropTypes.string,
+    model: PropTypes.object,
+    name: PropTypes.string,
     onCheckedChange: PropTypes.func,
     style: PropTypes.object,
     testID: PropTypes.string
   })
+
   state = {
-    checked: this.props.defaultChecked
+    checked: this.defaultChecked()
   }
 
-  setup() {}
+  setup() {
+    const {inputProps, restProps: useInputRestProps, wrapperOpts} = useInput({props: this.props, wrapperOptions: {type: "checkbox"}})
+    const isChecked = this.calculateChecked()
+
+    this.form = useForm()
+    this.inputProps = inputProps
+    this.useInputRestProps = useInputRestProps
+    this.wrapperOpts = wrapperOpts
+
+    useEffect(() => {
+      if (this.tt.form && inputProps.name) {
+        this.tt.form.setValue(inputProps.name, isChecked)
+      }
+    }, [inputProps.name, isChecked])
+  }
 
   calculateChecked() {
     if ("checked" in this.props) {
-      return this.p.checked
+      return Boolean(this.p.checked)
     } else {
       return this.s.checked
     }
   }
 
   render() {
-    const {dataSet, label, style, testID} = this.p
+    const {inputProps, useInputRestProps, wrapperOpts} = this.tt
+    const {
+      attribute,
+      checked,
+      dataSet,
+      defaultChecked,
+      id,
+      inputRef,
+      label,
+      model,
+      name,
+      onCheckedChange,
+      style,
+      testID,
+      ...restProps
+    } = useInputRestProps
     const isChecked = this.calculateChecked()
+    const actualLabel = typeof label == "undefined" ? wrapperOpts.label : label
     const actualStyle = useMemo(() => Object.assign({flexDirection: "row", alignItems: "center"}, style), [style])
     const actualDataSet = useMemo(() => Object.assign({checked: isChecked}, dataSet), [dataSet, isChecked])
 
@@ -65,11 +107,18 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
         dataSet={this.cache("viewContainerDataSet", {component: "api-maker/utils/checkbox"})}
         style={actualStyle}
       >
-        <CheckBox dataSet={actualDataSet} onValueChange={this.tt.onValueChange} testID={testID} value={isChecked} />
-        {label &&
+        <CheckBox
+          {...restProps}
+          dataSet={actualDataSet}
+          onValueChange={this.tt.onValueChange}
+          ref={inputProps.ref}
+          testID={testID}
+          value={isChecked}
+        />
+        {actualLabel &&
           <Pressable onPress={this.tt.onLabelPressed}>
             <Text style={this.cache("textStyle", {marginLeft: 3})}>
-              {label}
+              {actualLabel}
             </Text>
           </Pressable>
         }
@@ -77,19 +126,37 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     )
   }
 
-  onLabelPressed = () => {
-    const newChecked = !this.calculateChecked()
+  defaultChecked() {
+    if ("defaultChecked" in this.props) {
+      return Boolean(this.props.defaultChecked)
+    } else if (this.props.attribute && this.props.model) {
+      if (!this.props.model[this.props.attribute]) {
+        throw new Error(`No such attribute: ${this.props.attribute}`)
+      }
 
-    if (this.props.onCheckedChange) {
-      this.p.onCheckedChange(newChecked)
-    }
-
-    if (!("checked" in this.props)) {
-      this.s.checked = newChecked
+      return Boolean(this.props.model[this.props.attribute]())
+    } else {
+      return false
     }
   }
 
+  onLabelPressed = () => {
+    const newChecked = !this.calculateChecked()
+
+    this.setChecked(newChecked)
+  }
+
   onValueChange = (newChecked) => {
+    this.setChecked(newChecked)
+  }
+
+  setChecked(newChecked) {
+    const {form, inputProps} = this.tt
+
+    if (form && inputProps.name) {
+      form.setValue(inputProps.name, newChecked)
+    }
+
     if (this.props.onCheckedChange) {
       this.p.onCheckedChange(newChecked)
     }

--- a/npm-api-maker/src/utils/checkbox.jsx
+++ b/npm-api-maker/src/utils/checkbox.jsx
@@ -58,18 +58,26 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
 
   setup() {
     const {inputProps, restProps: useInputRestProps, wrapperOpts} = useInput({props: this.props, wrapperOptions: {type: "checkbox"}})
+    const form = useForm()
+    const inputName = inputProps.name
     const isChecked = this.calculateChecked()
 
-    this.form = useForm()
+    this.form = form
     this.inputProps = inputProps
     this.useInputRestProps = useInputRestProps
     this.wrapperOpts = wrapperOpts
 
     useEffect(() => {
-      if (this.tt.form && inputProps.name) {
-        this.tt.form.setValue(inputProps.name, isChecked)
+      if (form && inputName) {
+        form.setValue(inputName, isChecked)
       }
-    }, [inputProps.name, isChecked])
+    }, [form, inputName, isChecked])
+
+    useEffect(() => () => {
+      if (form && inputName) {
+        form.unsetValue(inputName)
+      }
+    }, [form, inputName])
   }
 
   calculateChecked() {

--- a/ruby-gem/spec/dummy/app/javascript/routes/utils/checkbox.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/utils/checkbox.jsx
@@ -9,15 +9,17 @@ import Params from "@kaspernj/api-maker/build/params.js"
 import React from "react"
 import Text from "@kaspernj/api-maker/build/utils/text"
 
-const formCheckboxDataSet = {testid: "utils-checkbox-form"}
-const submitPressableProps = {testID: "utils-checkbox-submit"}
-const uncontrolledDataSet = {testid: "utils-checkbox-uncontrolled"}
+/** @type {Record<string, object>} */
+const dataSets = {}
+/** @type {Record<string, object>} */
+const pressableProps = {}
 
 export default class RoutesUtilsCheckbox extends React.PureComponent {
   form = new FormInputs({})
 
   state = {
     savedFormValue: "",
+    showFormCheckbox: true,
     task: undefined
   }
 
@@ -26,27 +28,34 @@ export default class RoutesUtilsCheckbox extends React.PureComponent {
   }
 
   render() {
-    const {savedFormValue, task} = this.state
+    const {savedFormValue, showFormCheckbox, task} = this.state
 
     return (
       <Layout>
-        <View dataSet={{testid: "utils-checkbox-wrapper"}}>
+        <View dataSet={dataSets.wrapper ||= {testid: "utils-checkbox-wrapper"}}>
           <Checkbox
-            dataSet={uncontrolledDataSet}
+            dataSet={dataSets.uncontrolledCheckbox ||= {testid: "utils-checkbox-uncontrolled"}}
             defaultChecked={false}
             label="Uncontrolled checkbox"
           />
           {task &&
             <View testID="utils-checkbox-form-wrapper">
               <Form form={this.form} onSubmit={this.onSubmit}>
-                <Checkbox
-                  attribute="finished"
-                  dataSet={formCheckboxDataSet}
-                  model={task}
+                {showFormCheckbox &&
+                  <Checkbox
+                    attribute="finished"
+                    dataSet={dataSets.formCheckbox ||= {testid: "utils-checkbox-form"}}
+                    model={task}
+                  />
+                }
+                <Button
+                  label="Hide"
+                  onPress={this.onHideFormCheckbox}
+                  pressableProps={pressableProps.hide ||= {testID: "utils-checkbox-hide"}}
                 />
                 <Button
                   label="Save"
-                  pressableProps={submitPressableProps}
+                  pressableProps={pressableProps.submit ||= {testID: "utils-checkbox-submit"}}
                   submit
                 />
               </Form>
@@ -70,12 +79,18 @@ export default class RoutesUtilsCheckbox extends React.PureComponent {
     }
   }
 
+  onHideFormCheckbox = () => this.setState({showFormCheckbox: false})
+
   onSubmit = async () => {
     const {task} = this.state
+    const formParams = this.form.asObject()
     const formValue = this.form.getValue("task[finished]")
+    const savedFormValue = typeof formValue == "undefined" ? "unset" : String(formValue)
 
-    await task.saveRaw(this.form.asObject())
+    if (formParams.task) {
+      await task.saveRaw(formParams)
+    }
 
-    this.setState({savedFormValue: String(formValue)})
+    this.setState({savedFormValue})
   }
 }

--- a/ruby-gem/spec/dummy/app/javascript/routes/utils/checkbox.jsx
+++ b/ruby-gem/spec/dummy/app/javascript/routes/utils/checkbox.jsx
@@ -1,21 +1,81 @@
 // @ts-check
+import {Form, FormInputs} from "@kaspernj/api-maker/build/form"
+import {Task} from "models.js"
+import {View} from "react-native"
+import Button from "@kaspernj/api-maker/build/utils/button"
 import Checkbox from "@kaspernj/api-maker/build/utils/checkbox"
 import Layout from "components/layout"
+import Params from "@kaspernj/api-maker/build/params.js"
 import React from "react"
-import {View} from "react-native"
+import Text from "@kaspernj/api-maker/build/utils/text"
+
+const formCheckboxDataSet = {testid: "utils-checkbox-form"}
+const submitPressableProps = {testID: "utils-checkbox-submit"}
+const uncontrolledDataSet = {testid: "utils-checkbox-uncontrolled"}
 
 export default class RoutesUtilsCheckbox extends React.PureComponent {
+  form = new FormInputs({})
+
+  state = {
+    savedFormValue: "",
+    task: undefined
+  }
+
+  componentDidMount() {
+    this.loadTask()
+  }
+
   render() {
+    const {savedFormValue, task} = this.state
+
     return (
       <Layout>
         <View dataSet={{testid: "utils-checkbox-wrapper"}}>
           <Checkbox
-            dataSet={{testid: "utils-checkbox-uncontrolled"}}
+            dataSet={uncontrolledDataSet}
             defaultChecked={false}
             label="Uncontrolled checkbox"
           />
+          {task &&
+            <View testID="utils-checkbox-form-wrapper">
+              <Form form={this.form} onSubmit={this.onSubmit}>
+                <Checkbox
+                  attribute="finished"
+                  dataSet={formCheckboxDataSet}
+                  model={task}
+                />
+                <Button
+                  label="Save"
+                  pressableProps={submitPressableProps}
+                  submit
+                />
+              </Form>
+              <Text testID="utils-checkbox-saved-form-value">
+                {savedFormValue}
+              </Text>
+            </View>
+          }
         </View>
       </Layout>
     )
+  }
+
+  async loadTask() {
+    const {task_id: taskId} = Params.parse()
+
+    if (taskId) {
+      const task = await Task.find(taskId)
+
+      this.setState({task})
+    }
+  }
+
+  onSubmit = async () => {
+    const {task} = this.state
+    const formValue = this.form.getValue("task[finished]")
+
+    await task.saveRaw(this.form.asObject())
+
+    this.setState({savedFormValue: String(formValue)})
   }
 }

--- a/ruby-gem/spec/dummy/yarn.lock
+++ b/ruby-gem/spec/dummy/yarn.lock
@@ -996,7 +996,7 @@
   integrity sha512-4B8B+3vFsY4eo33DMKyJPlQ3sBMpPFUZK2dr3O3rXrOGKKbYG44J0XSFkDo1VOQiri5HFEhIeVvItjR2xcazmg==
 
 "@kaspernj/api-maker@file:../../../npm-api-maker":
-  version "1.0.2167"
+  version "1.0.2169"
   dependencies:
     classnames "^2.5.1"
     clone-deep ">= 4.0.1"
@@ -1019,7 +1019,7 @@
     qs ">= 6.9.3"
     replaceall ">= 0.1.6"
     responsive-breakpoints ">= 0.1.3"
-    set-state-compare "^1.0.84"
+    set-state-compare "^1.0.86"
     spark-md5 "^3.0.2"
     stacktrace-parser "^0.1.10"
     strftime ">= 0.10.0"
@@ -4178,6 +4178,14 @@ set-function-length@^1.2.2:
   version "1.0.84"
   resolved "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.84.tgz"
   integrity sha512-9n3zn0gbMaq+NJpAgc54zQXRQ8lV7b8TmDWJUIns9QS9MSij/mtaGAr5rCbLB+W1+tQ60KvDbgZyrWtDtXoDHg==
+  dependencies:
+    diggerize "^1.0.5"
+    fetching-object "^1.0.7"
+
+set-state-compare@^1.0.86:
+  version "1.0.86"
+  resolved "https://registry.yarnpkg.com/set-state-compare/-/set-state-compare-1.0.86.tgz#12b35151456866079247a209ab4ed75eddd2d3fa"
+  integrity sha512-0Gl2qXougZnPCC36d5n/OyRCiKowlhSlGr23Weo1TSyrsb6Iiak5roUAY6CuHII4u5FQtczsh0EFANHgvw1jhg==
   dependencies:
     diggerize "^1.0.5"
     fetching-object "^1.0.7"

--- a/ruby-gem/spec/dummy/yarn.lock
+++ b/ruby-gem/spec/dummy/yarn.lock
@@ -996,7 +996,7 @@
   integrity sha512-4B8B+3vFsY4eo33DMKyJPlQ3sBMpPFUZK2dr3O3rXrOGKKbYG44J0XSFkDo1VOQiri5HFEhIeVvItjR2xcazmg==
 
 "@kaspernj/api-maker@file:../../../npm-api-maker":
-  version "1.0.2169"
+  version "1.0.2167"
   dependencies:
     classnames "^2.5.1"
     clone-deep ">= 4.0.1"
@@ -1019,7 +1019,7 @@
     qs ">= 6.9.3"
     replaceall ">= 0.1.6"
     responsive-breakpoints ">= 0.1.3"
-    set-state-compare "^1.0.86"
+    set-state-compare "^1.0.84"
     spark-md5 "^3.0.2"
     stacktrace-parser "^0.1.10"
     strftime ">= 0.10.0"
@@ -4178,14 +4178,6 @@ set-function-length@^1.2.2:
   version "1.0.84"
   resolved "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.84.tgz"
   integrity sha512-9n3zn0gbMaq+NJpAgc54zQXRQ8lV7b8TmDWJUIns9QS9MSij/mtaGAr5rCbLB+W1+tQ60KvDbgZyrWtDtXoDHg==
-  dependencies:
-    diggerize "^1.0.5"
-    fetching-object "^1.0.7"
-
-set-state-compare@^1.0.86:
-  version "1.0.86"
-  resolved "https://registry.yarnpkg.com/set-state-compare/-/set-state-compare-1.0.86.tgz#12b35151456866079247a209ab4ed75eddd2d3fa"
-  integrity sha512-0Gl2qXougZnPCC36d5n/OyRCiKowlhSlGr23Weo1TSyrsb6Iiak5roUAY6CuHII4u5FQtczsh0EFANHgvw1jhg==
   dependencies:
     diggerize "^1.0.5"
     fetching-object "^1.0.7"

--- a/ruby-gem/spec/system/utils/checkbox_spec.rb
+++ b/ruby-gem/spec/system/utils/checkbox_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe "utils - checkbox" do
+  let(:task) { create :task, user: }
   let(:user) { create :user }
 
   it "toggles when uncontrolled" do
@@ -10,5 +11,39 @@ describe "utils - checkbox" do
     wait_for_selector "[data-testid='utils-checkbox-uncontrolled'][data-checked='false']"
     wait_for_and_find("[data-testid='utils-checkbox-uncontrolled']").click
     wait_for_selector "[data-testid='utils-checkbox-uncontrolled'][data-checked='true']"
+  end
+
+  it "sets the form value from the model default before interaction" do
+    task.update!(finished: true)
+
+    login_as user
+    visit utils_checkbox_path(task_id: task.id)
+
+    wait_for_selector "[data-testid='utils-checkbox-form'][data-checked='true']"
+    wait_for_and_find("[data-testid='utils-checkbox-submit']").click
+    wait_for_selector "[data-testid='utils-checkbox-saved-form-value']", text: "true"
+    expect(task.reload).to be_finished
+  end
+
+  it "sets false as the form value from the model default before interaction" do
+    login_as user
+    visit utils_checkbox_path(task_id: task.id)
+
+    wait_for_selector "[data-testid='utils-checkbox-form'][data-checked='false']"
+    wait_for_and_find("[data-testid='utils-checkbox-submit']").click
+    wait_for_selector "[data-testid='utils-checkbox-saved-form-value']", text: "false"
+    expect(task.reload).not_to be_finished
+  end
+
+  it "updates the form value when changed" do
+    login_as user
+    visit utils_checkbox_path(task_id: task.id)
+
+    wait_for_selector "[data-testid='utils-checkbox-form'][data-checked='false']"
+    wait_for_and_find("[data-testid='utils-checkbox-form']").click
+    wait_for_selector "[data-testid='utils-checkbox-form'][data-checked='true']"
+    wait_for_and_find("[data-testid='utils-checkbox-submit']").click
+    wait_for_selector "[data-testid='utils-checkbox-saved-form-value']", text: "true"
+    expect(task.reload).to be_finished
   end
 end

--- a/ruby-gem/spec/system/utils/checkbox_spec.rb
+++ b/ruby-gem/spec/system/utils/checkbox_spec.rb
@@ -46,4 +46,17 @@ describe "utils - checkbox" do
     wait_for_selector "[data-testid='utils-checkbox-saved-form-value']", text: "true"
     expect(task.reload).to be_finished
   end
+
+  it "removes the form value when unmounted" do
+    task.update!(finished: true)
+
+    login_as user
+    visit utils_checkbox_path(task_id: task.id)
+
+    wait_for_selector "[data-testid='utils-checkbox-form'][data-checked='true']"
+    wait_for_and_find("[data-testid='utils-checkbox-hide']").click
+    wait_for_and_find("[data-testid='utils-checkbox-submit']").click
+    wait_for_selector "[data-testid='utils-checkbox-saved-form-value']", text: "unset"
+    expect(task.reload).to be_finished
+  end
 end


### PR DESCRIPTION
## Summary
- Add ApiMaker FormInputs support to the React Native utils checkbox.
- Seed model/default checked values into the form before user interaction.
- Cover true, false, and changed checkbox form values in the dummy system spec.

## Tests
- npm run typecheck:file --file=src/utils/checkbox.jsx
- npm run lint:eslint -- src/utils/checkbox.jsx
- bundle exec rubocop spec/system/utils/checkbox_spec.rb
- ruby-gem/scripts/run-system-spec.sh spec/system/utils/checkbox_spec.rb (with Ruby 3.3.5 and a temporary Corepack yarn shim)
