### PR TITLE
Fix timeout guard error reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Notes:
 - Avoid unrelated changes (for example, adding placeholder modules in specs) unless they are necessary for the requested change.
 - Before committing, review the current diff and propose commit message(s) grouped by logical change sets.
 - Prefer `describe` over `RSpec.describe` in specs.
+- Prefer `expect(...).to receive(...)` over `allow(...)` in specs whenever the call is part of the behavior under test; reserve `allow` for background setup where call verification is intentionally irrelevant.
 - Do not add `# frozen_string_literal: true` to files.
 - Before adding RuboCop disable directives, check the existing repo RuboCop config first and prefer code that passes under that config without new disables; avoid review-only style churn.
 - Prefer multiple small, individually working commits when possible.

--- a/changelog.d/20260521-command-timeout-guard-error-reporting.md
+++ b/changelog.d/20260521-command-timeout-guard-error-reporting.md
@@ -1,0 +1,1 @@
+Fixed command timeout guard internal error reporting to use ApiMaker's standard keyword error callback payload.

--- a/ruby-gem/app/services/api_maker/command_timeout_guard.rb
+++ b/ruby-gem/app/services/api_maker/command_timeout_guard.rb
@@ -117,11 +117,6 @@ private
   end
 
   def report_error(error)
-    ApiMaker::Configuration.current.report_error(
-      command: nil,
-      controller: nil,
-      error:,
-      response: nil
-    )
+    ApiMaker::Configuration.current.report_error(error:)
   end
 end

--- a/ruby-gem/app/services/api_maker/command_timeout_guard.rb
+++ b/ruby-gem/app/services/api_maker/command_timeout_guard.rb
@@ -49,7 +49,7 @@ private
       begin
         @connection.execute(reset_sql)
       rescue StandardError => e
-        ApiMaker::Configuration.current.report_error(e)
+        report_error(e)
       end
     end
   end
@@ -87,7 +87,7 @@ private
         worker.raise(ApiMaker::CommandTimeoutError.new("Command exceeded timeout of #{@timeout_seconds}s"))
       end
     rescue StandardError => e
-      ApiMaker::Configuration.current.report_error(e)
+      report_error(e)
     end
 
     begin
@@ -113,6 +113,15 @@ private
 
     raw_connection.cancel
   rescue StandardError => e
-    ApiMaker::Configuration.current.report_error(e)
+    report_error(e)
+  end
+
+  def report_error(error)
+    ApiMaker::Configuration.current.report_error(
+      command: nil,
+      controller: nil,
+      error:,
+      response: nil
+    )
   end
 end

--- a/ruby-gem/lib/api_maker/configuration.rb
+++ b/ruby-gem/lib/api_maker/configuration.rb
@@ -65,9 +65,9 @@ class ApiMaker::Configuration
     @on_thread_callbacks << blk
   end
 
-  def report_error(...)
+  def report_error(command: nil, controller: nil, error:, response: nil)
     @on_error.each do |on_error|
-      on_error.call(...)
+      on_error.call(command:, controller:, error:, response:)
     end
   end
 end

--- a/ruby-gem/spec/services/api_maker/command_timeout_guard_spec.rb
+++ b/ruby-gem/spec/services/api_maker/command_timeout_guard_spec.rb
@@ -3,6 +3,15 @@ require "rails_helper"
 describe ApiMaker::CommandTimeoutGuard do
   let(:connection) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
 
+  around do |example|
+    config = ApiMaker::Configuration.current
+    original_on_error = config.instance_variable_get(:@on_error).dup
+
+    example.run
+  ensure
+    config.instance_variable_set(:@on_error, original_on_error)
+  end
+
   before do
     allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
     allow(ApiMaker::ConnectionDatabaseKind).to receive(:for).with(connection).and_return(:other)
@@ -86,6 +95,31 @@ describe ApiMaker::CommandTimeoutGuard do
       expect do
         described_class.wrap { raise "boom" }
       end.to raise_error("boom")
+    end
+
+    it "reports statement timeout reset failures with the standard keyword payload" do
+      reset_error = StandardError.new("reset failed")
+      reported_errors = []
+
+      ApiMaker::Configuration.current.on_error do |command:, controller:, error:, response:|
+        reported_errors << {command:, controller:, error:, response:}
+      end
+
+      allow(ApiMaker::Configuration.current).to receive(:command_timeout).and_return(5)
+      allow(ApiMaker::ConnectionDatabaseKind).to receive(:for).with(connection).and_return(:postgres)
+      allow(connection).to receive(:raw_connection).and_return(nil)
+      expect(connection).to receive(:execute).with("SET statement_timeout = 5000").ordered
+      expect(connection).to receive(:execute).with("RESET statement_timeout").ordered.and_raise(reset_error)
+
+      expect(described_class.wrap { :ok }).to eq(:ok)
+      expect(reported_errors).to eq [
+        {
+          command: nil,
+          controller: nil,
+          error: reset_error,
+          response: nil
+        }
+      ]
     end
   end
 end

--- a/ruby-gem/spec/services/api_maker/command_timeout_guard_spec.rb
+++ b/ruby-gem/spec/services/api_maker/command_timeout_guard_spec.rb
@@ -105,9 +105,10 @@ describe ApiMaker::CommandTimeoutGuard do
         reported_errors << {command:, controller:, error:, response:}
       end
 
-      allow(ApiMaker::Configuration.current).to receive(:command_timeout).and_return(5)
-      allow(ApiMaker::ConnectionDatabaseKind).to receive(:for).with(connection).and_return(:postgres)
-      allow(connection).to receive(:raw_connection).and_return(nil)
+      expect(ApiMaker::Configuration.current).to receive(:command_timeout).and_return(5)
+      expect(ActiveRecord::Base).to receive(:connection).and_return(connection)
+      expect(ApiMaker::ConnectionDatabaseKind).to receive(:for).with(connection).twice.and_return(:postgres)
+      expect(connection).to receive(:raw_connection).and_return(nil)
       expect(connection).to receive(:execute).with("SET statement_timeout = 5000").ordered
       expect(connection).to receive(:execute).with("RESET statement_timeout").ordered.and_raise(reset_error)
 


### PR DESCRIPTION
## Summary
- Report `ApiMaker::CommandTimeoutGuard` internal errors through the standard keyword `on_error` payload.
- Add regression coverage for keyword-only error callbacks when statement-timeout reset reporting fails.

## Testing
- `bundle exec rubocop app/services/api_maker/command_timeout_guard.rb spec/services/api_maker/command_timeout_guard_spec.rb`
- `bundle exec rspec spec/services/api_maker/command_timeout_guard_spec.rb`
- `git diff --check`