### PR TITLE
Use release-patch package for release:patch script

### DIFF
--- a/npm-api-maker/package-lock.json
+++ b/npm-api-maker/package-lock.json
@@ -64,6 +64,7 @@
         "react-dom": "19.0.0",
         "react-native": "0.79.6",
         "react-native-vector-icons": "^10.3.0",
+        "release-patch": "^1.0.0",
         "typescript": "~5.8.3",
         "velocious": "^1.0.343"
       },
@@ -16218,6 +16219,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/release-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-patch/-/release-patch-1.0.0.tgz",
+      "integrity": "sha512-reIEGt3J0eK2XF4x+YhusAXGxVHt2847iDBhbF+UGMd3JIfvxsiaMl+C1iZAjJCJShQDKJbh/mGquNm4Fy3TyA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "release-patch": "bin/release-patch.js"
       }
     },
     "node_modules/replaceall": {

--- a/npm-api-maker/package.json
+++ b/npm-api-maker/package.json
@@ -18,7 +18,7 @@
     "open:ios": "xed example/ios",
     "open:android": "open -a \"Android Studio\" example/android",
     "lint:eslint": "eslint --max-warnings 0 --ext .js,.jsx",
-    "release:patch": "node scripts/release-patch.js",
+    "release:patch": "release-patch",
     "release:patch-master": "node scripts/release-patch.js --require-master",
     "typecheck": "tsc --noEmit",
     "typecheck:file": "sh -c 'file=\"${npm_config_file:-${FILE:-}}\"; if [ -z \"$file\" ] && [ \"${0#--file=}\" != \"$0\" ]; then file=\"${0#--file=}\"; fi; if [ -z \"$file\" ] && [ \"${1#--file=}\" != \"$1\" ]; then file=\"${1#--file=}\"; fi; file=\"${file#npm-api-maker/}\"; file=\"${file#./}\"; if [ -z \"$file\" ]; then echo \"Missing --file=src/path/to/file.js\"; exit 2; fi; tmp=$(mktemp); tsc --noEmit -p tsconfig.json --pretty false >\"$tmp\" 2>&1; if rg --fixed-strings \"$file\" \"$tmp\" >/dev/null; then rg --fixed-strings \"$file\" \"$tmp\"; rm -f \"$tmp\"; exit 1; else rm -f \"$tmp\"; exit 0; fi'",
@@ -96,6 +96,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
     "react-native-vector-icons": "^10.3.0",
+    "release-patch": "^1.0.0",
     "typescript": "~5.8.3",
     "velocious": "^1.0.343"
   },


### PR DESCRIPTION
## Summary

Replaces this repo's custom `release:patch` script with the reusable [`release-patch`](https://github.com/kaspernj/release-patch) CLI ([npm](https://www.npmjs.com/package/release-patch)), so the release flow is shared across packages instead of duplicated per repo.

- Sets `"release:patch": "release-patch"`
- Adds `release-patch` as a devDependency

`release-patch` syncs `master`, runs `npm run build` when a `build` script exists, bumps the patch version without a tag, installs, commits, pushes to `master`, and publishes.

## Test plan

- `release-patch` bin resolves via `node_modules/.bin/release-patch`
- Not executed locally (it performs a real release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
