### PR TITLE
Table: warn before loading a dangerous number of rows

### DIFF
--- a/changelog.d/20260608-table-large-per-page-warning-modal.md
+++ b/changelog.d/20260608-table-large-per-page-warning-modal.md
@@ -1,0 +1,1 @@
+Added a confirmation modal in the live table that warns before loading a dangerous number of rows (e.g. the "All" per-page option on a large collection). It advises filtering and points to the existing Download export, and lets the user proceed or cancel. The threshold is configurable via `apiMakerConfig.setDangerousRowCountThreshold` (default 1000).

--- a/npm-api-maker/src/config.js
+++ b/npm-api-maker/src/config.js
@@ -28,6 +28,7 @@ const accessors = {
   },
   cableUrl: {require: false},
   currenciesCollection: {required: true},
+  dangerousRowCountThreshold: {default: 1000, required: false},
   history: {required: true},
   host: {required: false},
   i18n: {required: false},
@@ -78,6 +79,16 @@ class ApiMakerConfig {
   getCableUrl() {
     return apiMakerConfigNotImplemented("getCableUrl")
   }
+
+  /** @returns {number} */
+  getDangerousRowCountThreshold() {
+    return apiMakerConfigNotImplemented("getDangerousRowCountThreshold")
+  }
+
+  /**
+   * @param {number} _newValue
+   */
+  setDangerousRowCountThreshold(_newValue) { apiMakerConfigNotImplemented("setDangerousRowCountThreshold") }
 
   /**
    * @param {string | undefined} _newValue

--- a/npm-api-maker/src/table/large-per-page-warning-modal.jsx
+++ b/npm-api-maker/src/table/large-per-page-warning-modal.jsx
@@ -1,0 +1,82 @@
+// @ts-check
+/* eslint-disable sort-imports, react/jsx-max-depth */
+import {ShapeComponent, shapeComponent} from "set-state-compare/build/shape-component.js"
+import apiMakerConfig from "../config.js"
+import Button from "../utils/button"
+import memo from "set-state-compare/build/memo.js"
+import PropTypes from "prop-types"
+import propTypesExact from "prop-types-exact"
+import React from "react"
+import Text from "../utils/text"
+import useI18n from "i18n-on-steroids/build/src/use-i18n.js"
+import {View} from "react-native"
+
+/**
+ * Confirmation shown when a user tries to load more rows than the configured dangerous threshold (e.g. the
+ * "All" per-page option on a very large collection). Warns that the load may freeze the browser, advises
+ * filtering, points to the existing Download export, and lets the user proceed or cancel.
+ *
+ * @typedef {object} Props
+ * @property {number} count
+ * @property {() => void} onConfirm
+ * @property {() => void} onRequestClose
+ */
+export default memo(shapeComponent(/** @augments {ShapeComponent<Props>} */ class ApiMakerTableLargePerPageWarningModal extends ShapeComponent {
+  static propTypes = propTypesExact({
+    count: PropTypes.number,
+    onConfirm: PropTypes.func.isRequired,
+    onRequestClose: PropTypes.func.isRequired
+  })
+
+  setup() {
+    const {t} = useI18n({namespace: "js.api_maker.table.large_per_page_warning_modal"})
+
+    this.t = t
+  }
+
+  render() {
+    const {count, onConfirm, onRequestClose, ...restProps} = this.p
+    const Modal = apiMakerConfig.getModal()
+    const warningDefault = "You're about to load %{count} rows. " +
+      "This can make the page very slow or even crash your browser."
+    const exportDefault = "To save the data as a file, open the table settings (the gear icon) and click " +
+      "Download — it saves the rows currently shown."
+
+    return (
+      <Modal onRequestClose={onRequestClose} {...restProps}>
+        <View
+          dataSet={this.cache("rootViewDataSet", {class: "large-per-page-warning-modal"})}
+          style={this.cache("rootViewStyle", {padding: 20})}
+          testID="large-per-page-warning-modal"
+        >
+          <Text style={this.cache("titleStyle", {fontSize: 18, fontWeight: "bold", marginBottom: 12})}>
+            {this.t(".title", {defaultValue: "Load a large number of rows?"})}
+          </Text>
+          <Text style={this.cache("warningStyle", {marginBottom: 8})}>
+            {this.t(".warning", {count, defaultValue: warningDefault})}
+          </Text>
+          <Text style={this.cache("filterAdviceStyle", {marginBottom: 8})}>
+            {this.t(".filter_advice", {defaultValue: "Consider narrowing your results with filters first."})}
+          </Text>
+          <Text style={this.cache("exportAdviceStyle", {marginBottom: 16})}>
+            {this.t(".export_advice", {defaultValue: exportDefault})}
+          </Text>
+          <View style={this.cache("buttonsViewStyle", {flexDirection: "row", justifyContent: "flex-end"})}>
+            <Button
+              label={this.t(".cancel", {defaultValue: "Cancel"})}
+              onPress={onRequestClose}
+              pressableProps={this.cache("cancelButtonProps", {testID: "large-per-page-cancel-button"})}
+            />
+            <View style={this.cache("buttonSpacerStyle", {width: 10})} />
+            <Button
+              danger
+              label={this.t(".proceed_anyway", {defaultValue: "Proceed anyway"})}
+              onPress={onConfirm}
+              pressableProps={this.cache("proceedButtonProps", {testID: "large-per-page-proceed-button"})}
+            />
+          </View>
+        </View>
+      </Modal>
+    )
+  }
+}))

--- a/npm-api-maker/src/table/table.jsx
+++ b/npm-api-maker/src/table/table.jsx
@@ -6,7 +6,9 @@
 import {dig, digg, digs} from "diggerize"
 import React, {createContext, useContext, useEffect, useMemo, useRef} from "react"
 import {Animated, Platform, Pressable, View} from "react-native"
+import apiMakerConfig from "../config.js"
 import BlockingOverlay from "./blocking-overlay"
+import LargePerPageWarningModal from "./large-per-page-warning-modal"
 import Card from "../bootstrap/card"
 import classNames from "classnames"
 import Collection from "../collection.js"
@@ -350,6 +352,8 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     draggedColumn: null,
     identifier: this.props.identifier || `${digg(this.p.modelClass.modelClassData(), "collectionKey")}-default`,
     lastUpdate: new Date(),
+    pendingPerPageValue: null,
+    perPageSelectNonce: 0,
     preload: undefined,
     preparedColumns: undefined,
     queryName: this.props.queryName || digg(this.p.modelClass.modelClassData(), "collectionKey"),
@@ -358,6 +362,7 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
     querySName: `${this.props.queryName || digg(this.p.modelClass.modelClassData(), "collectionKey")}_s`,
     resizing: false,
     showFilters: Boolean(Params.parse()[`${this.props.queryName || digg(this.p.modelClass.modelClassData(), "collectionKey")}_s`]),
+    showLargePerPageWarning: false,
     showSettings: false,
     tableSetting: undefined,
     tableSettingLoaded: false,
@@ -947,14 +952,39 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
   }
 
   onPerPageChanged = (e) => {
-    const {queryName} = this.s
     const newPerPageValue = digg(e, "target", "value")
-    const perKey = `${queryName}_per`
-    const paramsChange = {}
+    const totalCount = this.collection?.result?.totalCount?.()
+    const wouldLoadCount = newPerPageValue == "all" ? totalCount : Math.min(Number(newPerPageValue), totalCount ?? Infinity)
 
-    paramsChange[perKey] = newPerPageValue
+    if (typeof totalCount == "number" && wouldLoadCount > apiMakerConfig.getDangerousRowCountThreshold()) {
+      this.s.pendingPerPageValue = newPerPageValue
+      this.s.showLargePerPageWarning = true
 
-    Params.changeParams(paramsChange)
+      return
+    }
+
+    this.applyPerPageChange(newPerPageValue)
+  }
+
+  applyPerPageChange = (newPerPageValue) => {
+    const {queryName} = this.s
+
+    Params.changeParams({[`${queryName}_per`]: newPerPageValue})
+  }
+
+  onConfirmLargePerPage = () => {
+    const {pendingPerPageValue} = this.s
+
+    this.s.pendingPerPageValue = null
+    this.s.showLargePerPageWarning = false
+    this.applyPerPageChange(pendingPerPageValue)
+  }
+
+  onCancelLargePerPage = () => {
+    this.s.pendingPerPageValue = null
+    this.s.showLargePerPageWarning = false
+    // Remount the uncontrolled per-page <Select> so it snaps back to the actual per-page value.
+    this.s.perPageSelectNonce += 1
   }
 
   renderItem = ({index, item: model}) => {
@@ -1167,10 +1197,18 @@ export default memo(shapeComponent(/** @augments {ShapeComponent<Props, State>} 
           <Select
             className="per-page-select"
             defaultValue={perPage}
+            key={`per-page-select-${this.s.perPageSelectNonce}`}
             onChange={this.tt.onPerPageChanged}
             options={paginationOptions}
           />
         </View>
+        {this.s.showLargePerPageWarning &&
+          <LargePerPageWarningModal
+            count={totalCount}
+            onConfirm={this.tt.onConfirmLargePerPage}
+            onRequestClose={this.tt.onCancelLargePerPage}
+          />
+        }
       </View>
     )
   }

--- a/ruby-gem/spec/system/api_maker_table/per_page_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/per_page_spec.rb
@@ -21,4 +21,34 @@ describe "bootstrap - live table - per page" do
     wait_for_and_find(".per-page-select").select("All")
     wait_for_expect { expect(all("[data-class='task-row']").length).to eq 100 }
   end
+
+  it "warns before loading a dangerous number of rows and lets the user proceed or cancel" do
+    project = create(:project)
+    now = Time.current
+    rows = Array.new(1001) do |index|
+      {name: "bulk-task-#{index}", project_id: project.id, state: "open", finished: false, created_at: now, updated_at: now}
+    end
+    Task.insert_all(rows) # rubocop:disable Rails/SkipsModelValidations
+
+    login_as user_admin
+    visit bootstrap_live_table_path
+    wait_for_expect { expect(all("[data-class='task-row']").length).to eq 30 }
+
+    # Selecting "All" above the threshold (default 1000) warns instead of loading everything.
+    wait_for_and_find(".per-page-select").select("All")
+    wait_for_selector "[data-testid='large-per-page-warning-modal']"
+    expect(all("[data-class='task-row']").length).to eq 30
+
+    # Cancelling keeps the current per-page.
+    wait_for_and_find("[data-testid='large-per-page-cancel-button']").click
+    wait_for_no_selector "[data-testid='large-per-page-warning-modal']"
+    expect(all("[data-class='task-row']").length).to eq 30
+
+    # Proceeding loads all the rows.
+    wait_for_and_find(".per-page-select").select("All")
+    wait_for_selector "[data-testid='large-per-page-warning-modal']"
+    wait_for_and_find("[data-testid='large-per-page-proceed-button']").click
+    wait_for_no_selector "[data-testid='large-per-page-warning-modal']"
+    wait_for_expect { expect(all("[data-class='task-row']").length).to eq 1001 }
+  end
 end


### PR DESCRIPTION
## Problem

On a large collection, selecting **"All"** in the table's per-page selector (`per=999999999`) loads every row. In wooftech this hit the admin contacts page (**326k contacts**) — it froze/crashed the browser and produced an `ApiMaker::CommandTimeoutError` (60s) server-side.

## Change

The table now intercepts a per-page selection that would load more rows than a configurable threshold and shows a confirmation modal instead of immediately loading:

- **`src/config.js`**: new accessor `dangerousRowCountThreshold` (default **1000**), so apps can tune it via `apiMakerConfig.setDangerousRowCountThreshold(...)`. (Getter/setter stubs added for the type checker, matching the existing accessor pattern.)
- **`src/table/table.jsx`**: `onPerPageChanged` computes the rows that would load (`"all"` → `result.totalCount()`) and, when it exceeds the threshold, opens the modal instead of changing params. Confirm applies the change; Cancel closes and remounts the (uncontrolled) per-page `<Select>` so it snaps back to the current value.
- **`src/table/large-per-page-warning-modal.jsx`** (new): warns the load may freeze/crash the browser, advises narrowing with filters, and points to the existing **Settings → Download** export. Buttons: **Proceed anyway** / **Cancel**. Strings use `js.api_maker.table.large_per_page_warning_modal.*` with English `defaultValue`s.

Small per-page values (30/60/90) and any total under the threshold are unaffected — no modal.

## Tests

Extended `spec/system/api_maker_table/per_page_spec.rb`: with 1001 rows, selecting "All" shows the warning modal (table still at 30); **Cancel** keeps the per-page; **Proceed anyway** loads all 1001. The existing per-page test (100 rows, under threshold) is unchanged and still selects "All" directly. Both pass.

## Follow-up (separate, in wooftech)

Publish the npm package and bump wooftech's `@kaspernj/api-maker`, and add Danish/Swedish/Norwegian translations for the new keys (English works out-of-the-box via `defaultValue`).