### PR TITLE
Detect and recover from frontend/backend auth divergence

### DIFF
--- a/npm-api-maker/__tests__/commands-pool.test.js
+++ b/npm-api-maker/__tests__/commands-pool.test.js
@@ -2,6 +2,7 @@
 import ApiMakerCommandsPool from "../src/commands-pool.js"
 import Config from "../src/config.js"
 import Devise from "../src/devise.js"
+import SessionExpiredError from "../src/session-expired-error.js"
 import SessionStatusUpdater from "../src/session-status-updater.js"
 import WebsocketRequestClient from "../src/websocket-request-client.js"
 import {jest} from "@jest/globals"
@@ -87,6 +88,78 @@ describe("ApiMakerCommandsPool", () => {
 
     expect(refreshSessionStatus).not.toHaveBeenCalled()
     expect(commandExecution.reject).toHaveBeenCalledTimes(1)
+  })
+
+  describe("believed signed-in identity", () => {
+    it("includes believed_devise_user_ids in the request global when signed in", () => {
+      const pool = new ApiMakerCommandsPool()
+
+      jest.spyOn(Devise, "registeredScopes").mockReturnValue(["user"])
+      jest.spyOn(Devise.current(), "getCurrentScope").mockReturnValue({id: () => 42})
+
+      expect(pool.globalDataForRequest()).toEqual({believed_devise_user_ids: {user: 42}})
+    })
+
+    it("omits believed_devise_user_ids when nothing is signed in", () => {
+      const pool = new ApiMakerCommandsPool()
+
+      jest.spyOn(Devise, "registeredScopes").mockReturnValue(["user"])
+      jest.spyOn(Devise.current(), "getCurrentScope").mockReturnValue(null)
+
+      expect(pool.globalDataForRequest()).toEqual({})
+    })
+  })
+
+  describe("authentication divergence recovery", () => {
+    it("retries after recovering from authentication_changed and returns the retried response", async() => {
+      const pool = new ApiMakerCommandsPool()
+      const performRequest = jest.spyOn(pool, "performRequest")
+        .mockResolvedValueOnce({success: false, type: "authentication_changed"})
+        .mockResolvedValueOnce({responses: {}})
+      const recover = jest.spyOn(pool, "recoverAuthentication").mockResolvedValue(true)
+
+      const response = await pool.sendRequest({commandSubmitData: {}, url: "/api_maker/commands"})
+
+      expect(recover).toHaveBeenCalledTimes(1)
+      expect(performRequest).toHaveBeenCalledTimes(2)
+      expect(response).toEqual({responses: {}})
+    })
+
+    it("throws SessionExpiredError when authentication_changed cannot be recovered", async() => {
+      const pool = new ApiMakerCommandsPool()
+
+      jest.spyOn(pool, "performRequest").mockResolvedValue({success: false, type: "authentication_changed"})
+      const recover = jest.spyOn(pool, "recoverAuthentication").mockResolvedValue(false)
+
+      await expect(pool.sendRequest({commandSubmitData: {}, url: "/api_maker/commands"})).rejects.toBeInstanceOf(SessionExpiredError)
+      expect(recover).toHaveBeenCalledTimes(1)
+    })
+
+    it("recoverAuthentication refreshes the websocket session and reports a still-signed-in user", async() => {
+      const pool = new ApiMakerCommandsPool()
+
+      jest.spyOn(Devise, "registeredScopes").mockReturnValue(["user"])
+      jest.spyOn(SessionStatusUpdater.current(), "sessionStatus").mockResolvedValue({scopes: {user: {signed_in: true}}, shadow_session_token: "tok"})
+      const applyResult = jest.spyOn(SessionStatusUpdater.current(), "applyResult").mockReturnValue(undefined)
+      const refresh = jest.spyOn(Devise, "refreshWebsocketSession").mockResolvedValue({})
+
+      const recovered = await pool.recoverAuthentication()
+
+      expect(refresh).toHaveBeenCalledWith({scope: "user", shadowSessionToken: "tok"})
+      expect(applyResult).toHaveBeenCalledTimes(1)
+      expect(recovered).toBe(true)
+    })
+
+    it("recoverAuthentication reports signed-out when the backend no longer has the user", async() => {
+      const pool = new ApiMakerCommandsPool()
+
+      jest.spyOn(Devise, "registeredScopes").mockReturnValue(["user"])
+      jest.spyOn(SessionStatusUpdater.current(), "sessionStatus").mockResolvedValue({scopes: {user: {signed_in: false}}})
+      jest.spyOn(SessionStatusUpdater.current(), "applyResult").mockReturnValue(undefined)
+      jest.spyOn(Devise, "refreshWebsocketSession").mockResolvedValue({})
+
+      expect(await pool.recoverAuthentication()).toBe(false)
+    })
   })
 
   describe("rejectWithCallerStack", () => {

--- a/npm-api-maker/__tests__/commands-pool.test.js
+++ b/npm-api-maker/__tests__/commands-pool.test.js
@@ -150,6 +150,23 @@ describe("ApiMakerCommandsPool", () => {
       expect(recovered).toBe(true)
     })
 
+    it("rejects queued command promises when a flush fails unrecoverably", async() => {
+      const pool = new ApiMakerCommandsPool()
+      const reject = jest.fn()
+
+      pool.pool = {1: {commandExecution: {reject, resolve: jest.fn()}}}
+      pool.poolData = {collection: {tasks: {test: {1: {args: {}, id: 1}}}}}
+
+      jest.spyOn(Devise, "registeredScopes").mockReturnValue([])
+      jest.spyOn(pool, "performRequest").mockResolvedValue({success: false, type: "authentication_changed"})
+      jest.spyOn(pool, "recoverAuthentication").mockResolvedValue(false)
+
+      await pool.flush()
+
+      expect(reject).toHaveBeenCalledTimes(1)
+      expect(reject.mock.calls[0][0]).toBeInstanceOf(SessionExpiredError)
+    })
+
     it("recoverAuthentication reports signed-out when the backend no longer has the user", async() => {
       const pool = new ApiMakerCommandsPool()
 

--- a/npm-api-maker/__tests__/session-status-updater.test.js
+++ b/npm-api-maker/__tests__/session-status-updater.test.js
@@ -14,4 +14,44 @@ describe("ApiMakerSessionStatusUpdater", () => {
 
     await expect(updater.getCsrfToken()).resolves.toBeUndefined()
   })
+
+  it("refreshes session status once when the page returns to the foreground from a burst of signals", () => {
+    jest.useFakeTimers()
+
+    try {
+      Object.defineProperty(document, "visibilityState", {configurable: true, get: () => "visible"})
+
+      const updater = new ApiMakerSessionStatusUpdater({useMetaElement: false})
+      const update = jest.spyOn(updater, "updateSessionStatus").mockResolvedValue(undefined)
+
+      // visibilitychange + focus + pageshow can all fire together on return.
+      updater.refreshOnReturnToForeground()
+      updater.refreshOnReturnToForeground()
+      updater.refreshOnReturnToForeground()
+
+      jest.advanceTimersByTime(60)
+
+      expect(update).toHaveBeenCalledTimes(1)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it("does not refresh session status while the page is hidden", () => {
+    jest.useFakeTimers()
+
+    try {
+      Object.defineProperty(document, "visibilityState", {configurable: true, get: () => "hidden"})
+
+      const updater = new ApiMakerSessionStatusUpdater({useMetaElement: false})
+      const update = jest.spyOn(updater, "updateSessionStatus").mockResolvedValue(undefined)
+
+      updater.refreshOnReturnToForeground()
+      jest.advanceTimersByTime(60)
+
+      expect(update).not.toHaveBeenCalled()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
 })

--- a/npm-api-maker/src/commands-pool.js
+++ b/npm-api-maker/src/commands-pool.js
@@ -338,6 +338,14 @@ export default class ApiMakerCommandsPool {
           throw new Error(`Unhandled response type: ${responseType}`)
         }
       }))
+    } catch (error) {
+      // sendRequest (e.g. an unrecoverable SessionExpiredError) or response
+      // handling can throw before the per-command promises are settled. Reject
+      // every queued command so callers awaiting their execution don't hang
+      // forever. Already-settled executions ignore the extra reject.
+      for (const commandData of Object.values(currentPool)) {
+        commandData.commandExecution.reject(/** @type {Error} */ (error))
+      }
     } finally {
       this.flushCount--
     }

--- a/npm-api-maker/src/commands-pool.js
+++ b/npm-api-maker/src/commands-pool.js
@@ -13,6 +13,7 @@ import events from "./events.js"
 import FormDataObjectizer from "form-data-objectizer" // eslint-disable-line sort-imports
 import RunLast from "./run-last.js"
 import Serializer from "./serializer.js"
+import SessionExpiredError from "./session-expired-error.js"
 import SessionStatusUpdater from "./session-status-updater.js"
 import ValidationError from "./validation-error.js"
 import {ValidationErrors} from "./validation-errors.js"
@@ -61,6 +62,7 @@ import WebsocketRequestClient from "./websocket-request-client.js"
  */
 
 /** @typedef {{[key: string]: {[key: string]: {[key: string]: {[key: number]: {args: object, primary_key: number | string, id: number}}}}}} PoolDataType */
+/** @typedef {import("./base-model.js").default & {id: () => number | string}} BaseModelWithId */
 
 const shared = {}
 
@@ -183,10 +185,42 @@ export default class ApiMakerCommandsPool {
    * @returns {Promise<CommandsRequestResponse>}
    */
   async sendRequest({commandExecution, commandSubmitData, url}) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await this.performRequest({commandExecution, commandSubmitData, url}) // eslint-disable-line no-await-in-loop
+
+      if (response?.success === false && response.type == "invalid_authenticity_token") {
+        console.log("Invalid authenticity token - try again")
+        await SessionStatusUpdater.current().updateSessionStatus() // eslint-disable-line no-await-in-loop
+        continue // eslint-disable-line no-continue
+      }
+
+      if (response?.success === false && response.type == "authentication_changed") {
+        const recovered = await this.recoverAuthentication() // eslint-disable-line no-await-in-loop
+
+        if (recovered) continue // eslint-disable-line no-continue
+
+        throw new SessionExpiredError()
+      }
+
+      return /** @type {CommandsRequestResponse} */ (response)
+    }
+
+    throw new Error("Couldnt successfully execute request")
+  }
+
+  /**
+   * Performs a single command request over websocket or HTTP.
+   * @param {object} args
+   * @param {string} args.url
+   * @param {CommandSubmitData} args.commandSubmitData
+   * @param {ApiMakerCommandExecution} [args.commandExecution]
+   * @returns {Promise<CommandsRequestResponse>}
+   */
+  async performRequest({commandExecution, commandSubmitData, url}) {
     if (Config.getWebsocketRequests() && !this.requestOptions.forceHttp && commandSubmitData.getFilesCount() == 0) {
       return /** @type {Promise<CommandsRequestResponse>} */ (WebsocketRequestClient.current().perform({
         cacheResponse: this.requestOptions.cacheResponse,
-        global: this.globalRequestData,
+        global: this.globalDataForRequest(),
         onLog: (message) => commandExecution?.addLog(message),
         onProgress: (progressData) => commandExecution?.setProgress(progressData),
         onReceived: (receivedData) => commandExecution?.setReceived(receivedData),
@@ -194,25 +228,65 @@ export default class ApiMakerCommandsPool {
       }))
     }
 
-    let response
-
-    for (let i = 0; i < 3; i++) {
-      if (commandSubmitData.getFilesCount() > 0) {
-        response = await Api.requestLocal({path: url, method: "POST", rawData: commandSubmitData.getFormData()}) // eslint-disable-line no-await-in-loop
-      } else {
-        response = await Api.requestLocal({path: url, method: "POST", data: commandSubmitData.getJsonData()}) // eslint-disable-line no-await-in-loop
-      }
-
-      if (response.success === false && response.type == "invalid_authenticity_token") {
-        console.log("Invalid authenticity token - try again")
-        await SessionStatusUpdater.current().updateSessionStatus() // eslint-disable-line no-await-in-loop
-        continue // eslint-disable-line no-continue
-      }
-
-      return /** @type {CommandsRequestResponse} */ (response)
+    if (commandSubmitData.getFilesCount() > 0) {
+      return /** @type {CommandsRequestResponse} */ (await Api.requestLocal({path: url, method: "POST", rawData: commandSubmitData.getFormData()}))
     }
 
-    throw new Error("Couldnt successfully execute request")
+    return /** @type {CommandsRequestResponse} */ (await Api.requestLocal({path: url, method: "POST", data: commandSubmitData.getJsonData()}))
+  }
+
+  /**
+   * The user ids the frontend believes it is signed in as, keyed by Devise
+   * scope. Sent with each request so the backend can detect (and let the
+   * frontend recover from) a stale session before running commands. Undefined
+   * when nothing is signed in, so genuinely anonymous requests send no belief.
+   * @returns {Record<string, number | string> | undefined}
+   */
+  believedDeviseUserIds() {
+    const believed = /** @type {Record<string, number | string>} */ ({})
+
+    for (const scope of Devise.registeredScopes()) {
+      const model = Devise.current().getCurrentScope(scope)
+
+      if (model) believed[scope] = /** @type {BaseModelWithId} */ (model).id()
+    }
+
+    return Object.keys(believed).length > 0 ? believed : undefined
+  }
+
+  /**
+   * The global request data merged with the believed signed-in identity.
+   * @returns {Record<string, unknown>}
+   */
+  globalDataForRequest() {
+    const believed = this.believedDeviseUserIds()
+
+    if (!believed) return this.globalRequestData
+
+    return {...this.globalRequestData, believed_devise_user_ids: believed}
+  }
+
+  /**
+   * Recovers from an `authentication_changed` response: refreshes the existing
+   * websocket connection's auth in-place from the current server session (no
+   * reconnect, no password) and reconciles the local session cache. Returns
+   * whether a previously signed-in scope is still authenticated, so the request
+   * can be retried; false means the user is genuinely signed out (the sign-in
+   * form is shown centrally via the Devise sign-out event).
+   * @returns {Promise<boolean>}
+   */
+  async recoverAuthentication() {
+    const sessionStatusUpdater = SessionStatusUpdater.current()
+    const sessionStatus = await sessionStatusUpdater.sessionStatus()
+    const scopes = Devise.registeredScopes()
+
+    await Promise.all(
+      scopes.map((scope) => Devise.refreshWebsocketSession({scope, shadowSessionToken: sessionStatus?.shadow_session_token}))
+    )
+
+    sessionStatusUpdater.applyResult(sessionStatus)
+
+    return scopes.some((scope) => Boolean(sessionStatus?.scopes?.[scope]?.signed_in))
   }
 
   /** Sends the currently queued commands and resolves or rejects their executions. */
@@ -230,9 +304,10 @@ export default class ApiMakerCommandsPool {
 
     try {
       const submitData = {pool: currentPoolData}
+      const globalData = this.globalDataForRequest()
 
-      if (Object.keys(this.globalRequestData).length > 0)
-        submitData.global = this.globalRequestData
+      if (Object.keys(globalData).length > 0)
+        submitData.global = globalData
 
       const commandSubmitData = new CommandSubmitData(submitData)
       const url = "/api_maker/commands"

--- a/npm-api-maker/src/session-expired-error.js
+++ b/npm-api-maker/src/session-expired-error.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+/**
+ * Raised by the commands pool when a request could not run because the session
+ * had expired (the frontend's believed user diverged from the backend's actual
+ * user) and could not be renewed. Callers can treat this as a benign "please
+ * sign in again" signal — the sign-in form is shown centrally via the Devise
+ * sign-out event — rather than a real command failure.
+ */
+export default class ApiMakerSessionExpiredError extends Error {
+  static apiMakerType = "SessionExpiredError"
+  apiMakerType = "SessionExpiredError"
+
+  /** @param {string} [message] */
+  constructor(message = "The session has expired") {
+    super(message)
+
+    if (Error.captureStackTrace) Error.captureStackTrace(this, ApiMakerSessionExpiredError)
+  }
+}

--- a/npm-api-maker/src/session-status-updater.js
+++ b/npm-api-maker/src/session-status-updater.js
@@ -19,6 +19,7 @@ const shared = {}
  * @typedef {object} SessionStatusResult
  * @property {string} [csrf_token]
  * @property {Record<string, SessionStatusScope>} scopes
+ * @property {string} [shadow_session_token]
  */
 
 /**
@@ -62,6 +63,10 @@ export default class ApiMakerSessionStatusUpdater {
       this.connectOnlineEvent()
     }
 
+    if (typeof document != "undefined") {
+      this.connectVisibilityEvents()
+    }
+
     this.connectWakeEvent()
   }
 
@@ -73,6 +78,39 @@ export default class ApiMakerSessionStatusUpdater {
   /** Re-checks session state when the device wakes from sleep. */
   connectWakeEvent() {
     wakeEvent(this.updateSessionStatus)
+  }
+
+  /**
+   * Re-checks session state when the user returns to a backgrounded tab/app.
+   * The `wake-event` package only fires on multi-second device-sleep drift, so
+   * it misses iOS Safari tab suspension; visibilitychange/focus/pageshow cover
+   * that, surfacing an expired session the moment the user returns.
+   */
+  connectVisibilityEvents() {
+    document.addEventListener("visibilitychange", this.refreshOnReturnToForeground, false)
+
+    if (typeof window != "undefined") {
+      window.addEventListener("focus", this.refreshOnReturnToForeground, false)
+      window.addEventListener("pageshow", this.refreshOnReturnToForeground, false)
+    }
+  }
+
+  /**
+   * Schedules a debounced session-status refresh when the page becomes visible
+   * again. visibilitychange, focus and pageshow can fire together on return, so
+   * the refresh is collapsed into a single request.
+   */
+  refreshOnReturnToForeground = () => {
+    if (typeof document != "undefined" && document.visibilityState && document.visibilityState != "visible") {
+      return
+    }
+
+    if (this.returnRefreshTimeout) return
+
+    this.returnRefreshTimeout = setTimeout(() => {
+      this.returnRefreshTimeout = undefined
+      this.updateSessionStatus()
+    }, 50)
   }
 
   async getCsrfToken() {

--- a/ruby-gem/app/services/api_maker/authentication_reconciler.rb
+++ b/ruby-gem/app/services/api_maker/authentication_reconciler.rb
@@ -1,0 +1,43 @@
+# Compares the user ids the frontend believes it is signed in as (sent in the
+# request's global data as `believed_devise_user_ids`) against the actually
+# authenticated user for each Devise scope.
+#
+# A divergence means the frontend's session belief is stale — the session
+# expired, was signed out, or switched accounts — so running the request as-is
+# would produce misleading "not found / no access" errors. Callers use this to
+# short-circuit with a dedicated `authentication_changed` response instead.
+#
+# The believed ids are used ONLY to detect divergence against the
+# server-authoritative user. They never grant access.
+class ApiMaker::AuthenticationReconciler
+  def self.diverged?(believed_user_ids:, actual_user_id_for:)
+    new(believed_user_ids:, actual_user_id_for:).diverged?
+  end
+
+  # @param believed_user_ids [Hash, nil] scope name => believed user id, as sent
+  #   by the frontend. Anything that is not a Hash is treated as "no belief".
+  # @param actual_user_id_for [#call] receives a scope name (String) and returns
+  #   the actually authenticated user id for that scope (or nil when signed out).
+  def initialize(believed_user_ids:, actual_user_id_for:)
+    @believed_user_ids = believed_user_ids
+    @actual_user_id_for = actual_user_id_for
+  end
+
+  def diverged?
+    believed_pairs.any? do |scope, believed_id|
+      @actual_user_id_for.call(scope).to_s != believed_id.to_s
+    end
+  end
+
+private
+
+  def believed_pairs
+    return [] unless @believed_user_ids.is_a?(Hash)
+
+    @believed_user_ids.filter_map do |scope, believed_id|
+      next if believed_id.nil? || believed_id.to_s.empty?
+
+      [scope.to_s, believed_id]
+    end
+  end
+end

--- a/ruby-gem/app/services/api_maker/command_request_executor.rb
+++ b/ruby-gem/app/services/api_maker/command_request_executor.rb
@@ -3,26 +3,62 @@ class ApiMaker::CommandRequestExecutor < ApiMaker::ApplicationService
 
   def perform
     with_request_context do
-      pool_data.each do |command_type, command_type_data|
-        command_type_data.each do |resource_plural_name, command_model_data|
-          command_model_data.each do |command_name, command_data|
-            ApiMaker.const_get("#{command_type.camelize}CommandService").execute!(
-              ability: controller.__send__(:current_ability),
-              api_maker_args: controller.__send__(:api_maker_args),
-              command_response:,
-              commands: normalize_commands(command_data),
-              command_name: command_name.to_s,
-              controller:,
-              resource_name: resource_plural_name.to_s
-            )
+      # The frontend's believed user is reconciled against the real one only
+      # after the request context has synced the authoritative current user.
+      # On divergence we short-circuit before running any command, so no
+      # misleading "not found / no access" error is raised or reported.
+      if authentication_diverged?
+        succeed!({success: false, type: :authentication_changed})
+      else
+        pool_data.each do |command_type, command_type_data|
+          command_type_data.each do |resource_plural_name, command_model_data|
+            command_model_data.each do |command_name, command_data|
+              ApiMaker.const_get("#{command_type.camelize}CommandService").execute!(
+                ability: controller.__send__(:current_ability),
+                api_maker_args: controller.__send__(:api_maker_args),
+                command_response:,
+                commands: normalize_commands(command_data),
+                command_name: command_name.to_s,
+                controller:,
+                resource_name: resource_plural_name.to_s
+              )
+            end
           end
         end
+
+        command_response.join_threads
+
+        succeed!({responses: command_response.result})
       end
-
-      command_response.join_threads
-
-      succeed!({responses: command_response.result})
     end
+  end
+
+  def authentication_diverged?
+    # Only member/collection commands load records through abilities and can
+    # surface a misleading "not found / no access" on stale auth. Service
+    # commands (notably the Devise session-refresh services used to recover
+    # from a divergence) must never be gated, or recovery could not run.
+    return false unless reconcilable_command_types?
+
+    ApiMaker::AuthenticationReconciler.diverged?(
+      believed_user_ids:,
+      actual_user_id_for: method(:actual_user_id_for)
+    )
+  end
+
+  def reconcilable_command_types?
+    pool_data.keys.map(&:to_s).intersect?(%w[member collection])
+  end
+
+  def believed_user_ids
+    global = merged_payload[:global] || merged_payload["global"]
+    return unless global.is_a?(Hash)
+
+    global[:believed_devise_user_ids] || global["believed_devise_user_ids"]
+  end
+
+  def actual_user_id_for(scope)
+    controller.__send__(:api_maker_args)[:"current_#{scope}"]&.id
   end
 
   def command_response

--- a/ruby-gem/spec/services/api_maker/authentication_reconciler_spec.rb
+++ b/ruby-gem/spec/services/api_maker/authentication_reconciler_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe ApiMaker::AuthenticationReconciler do
+  def diverged?(believed_user_ids:, actual: {})
+    described_class.diverged?(
+      believed_user_ids:,
+      actual_user_id_for: ->(scope) { actual[scope] }
+    )
+  end
+
+  it "is not diverged when the believed user matches the actual user" do
+    expect(diverged?(believed_user_ids: {"user" => 5}, actual: {"user" => 5})).to be(false)
+  end
+
+  it "is diverged when the actual user is signed out" do
+    expect(diverged?(believed_user_ids: {"user" => 5}, actual: {"user" => nil})).to be(true)
+  end
+
+  it "is diverged when the actual user is a different id" do
+    expect(diverged?(believed_user_ids: {"user" => 5}, actual: {"user" => 9})).to be(true)
+  end
+
+  it "is not diverged when there is no belief" do
+    expect(diverged?(believed_user_ids: nil)).to be(false)
+    expect(diverged?(believed_user_ids: {})).to be(false)
+  end
+
+  it "is not diverged for a non-hash believed payload" do
+    expect(diverged?(believed_user_ids: "garbage")).to be(false)
+  end
+
+  it "ignores blank believed ids" do
+    expect(diverged?(believed_user_ids: {"user" => ""}, actual: {"user" => nil})).to be(false)
+  end
+
+  it "compares ids as strings so string and integer ids match" do
+    expect(diverged?(believed_user_ids: {"user" => "5"}, actual: {"user" => 5})).to be(false)
+  end
+end

--- a/ruby-gem/spec/services/api_maker/command_request_executor_spec.rb
+++ b/ruby-gem/spec/services/api_maker/command_request_executor_spec.rb
@@ -124,6 +124,57 @@ describe ApiMaker::CommandRequestExecutor do
     )
   end
 
+  it "short-circuits with authentication_changed when the believed user diverges from the actual user" do
+    expect(controller).to receive(:with_request_context).and_yield
+
+    response = described_class.execute!(
+      controller:,
+      payload: {
+        "global" => {"believed_devise_user_ids" => {"user" => "does-not-match"}},
+        "pool" => {
+          "collection" => {
+            "tasks" => {
+              "test_collection" => {
+                "1" => {
+                  "args" => {},
+                  "id" => 1
+                }
+              }
+            }
+          }
+        }
+      }
+    )
+
+    expect(response).to eq(success: false, type: :authentication_changed)
+  end
+
+  it "runs commands normally when the believed user matches the actual user" do
+    expect(controller).to receive(:with_request_context).and_yield
+
+    response = described_class.execute!(
+      controller:,
+      payload: {
+        "global" => {"believed_devise_user_ids" => {"user" => current_user.id}},
+        "pool" => {
+          "collection" => {
+            "tasks" => {
+              "test_collection" => {
+                "1" => {
+                  "args" => {},
+                  "id" => 1
+                }
+              }
+            }
+          }
+        }
+      }
+    )
+
+    expect(response).to include(:responses)
+    expect(response.fetch(:responses).fetch("1")).to include(type: :success)
+  end
+
   it "transmits command progress and log events through current_command" do
     expect(controller).to receive(:with_request_context).and_yield
     expect(controller).to receive(:transmit_command_event).with(


### PR DESCRIPTION
## Why

When a client's login session expires — e.g. an idle iPad whose websocket reconnected anonymous — the frontend can still believe it is signed in. Member/collection commands then ran server-side with no current user, so `ApiMaker::IndividualCommand#model` raised `NotFoundOrNoAccessError` ("Couldn't find or no access to …"). That surfaces a misleading "no access" crash to the user and noise to error trackers, when the real problem is an **authentication-state divergence**, not an authorization failure.

## What

Explicitly reconcile identity, then renew-and-retry before giving up:

1. **Frontend declares belief.** The command pool attaches `believed_devise_user_ids` (per Devise scope, from the local Devise cache) to each request's global data. Anonymous requests send nothing.
2. **Backend reconciles** (`AuthenticationReconciler` + a single chokepoint in `CommandRequestExecutor#perform`, after the real user is synced, before any command runs). On divergence it short-circuits with a request-level `{success: false, type: "authentication_changed"}` and executes **no** command — so `NotFoundOrNoAccessError` is never raised or reported. Only `member`/`collection` commands are gated; **service** commands (notably the Devise session-refresh used for recovery) are never gated.
3. **Frontend recovers.** On `authentication_changed` the pool attempts an in-place websocket session renewal for the same user via the existing `Devise.refreshWebsocketSession` primitive (no reconnect, no password) and **auto-retries** when the session is restored; otherwise it rejects with a typed `SessionExpiredError` so the sign-in form is shown centrally (via the Devise sign-out event).
4. **Proactive refresh.** `SessionStatusUpdater` now also listens for `visibilitychange`/`focus`/`pageshow` (debounced), so an expired session surfaces the moment the user returns to a backgrounded tab — the existing `wake-event` drift check misses iOS Safari tab suspension.

The believed ids are used **only** to detect divergence against the server-authoritative user; they never grant access (distinct field name, never override `current_user`).

This mirrors the existing `invalid_authenticity_token` request-level recovery precedent.

## Tests

- Gem: `authentication_reconciler_spec` (match / signed-out / different-id / no-belief / blank / string-vs-int); `command_request_executor_spec` (divergence short-circuits with `authentication_changed` and runs no command; matching belief runs normally).
- npm: `commands-pool.test` (belief attached only when signed in; `authentication_changed` → recover+retry; unrecoverable → `SessionExpiredError`, no retry; `recoverAuthentication` signed-in/out); `session-status-updater.test` (debounced foreground refresh; no refresh while hidden).
- Full gem rspec for touched area green; full npm `lint` (eslint + typecheck) and all 141 jest tests green.

## Follow-up (separate, in wooftech)

- Bump wooftech to the released api_maker version; optionally treat `SessionExpiredError` as a benign/friendly message in the global error surface.
- Decide whether to lengthen the recovery window (Devise rememberable / sliding cookie) so silent renewal succeeds for longer-idle sessions — renewal only works while a server-side recovery credential still exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
