### PR TITLE
Fix large per-page Firefox system spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Notes:
 - If `ruby-gem/scripts/run-system-spec.sh` fails, run the README system spec command manually from `ruby-gem/`.
 - In `ApiMaker::ModelContentGeneratorService`, handle Ransack allowlist runtime errors (`"Ransack needs ..."`) for associations/attributes/scopes by returning `[]` so frontend model generation does not crash on third-party models.
 - Do not “fix” flaky specs by only increasing waits/timeouts. First determine whether behavior regressed (for example, element never rendered) and collect/inspect CI artifacts before adjusting timing.
+- When a system spec asserts the full DOM row count for a large React Native `FlatList`, configure `initialNumToRender` and `maxToRenderPerBatch` for the fixture size so the assertion tests loaded data rather than asynchronous list batching.
 - Avoid unnecessary defensive conditions for guaranteed contracts. Prefer failing fast over silently accepting impossible states.
 - In ApiMaker table workplace helpers and commands, `current_user` may legitimately be `nil` for websocket/content-parser requests; return `nil`/empty results for current-workplace lookups instead of dereferencing the user.
 - Before adding fallback logic for hook/context timing, inspect the provider source first; do not assume first-render hydration gaps without source confirmation.

--- a/ruby-gem/spec/system/api_maker_table/per_page_spec.rb
+++ b/ruby-gem/spec/system/api_maker_table/per_page_spec.rb
@@ -31,7 +31,8 @@ describe "bootstrap - live table - per page" do
     Task.insert_all(rows) # rubocop:disable Rails/SkipsModelValidations
 
     login_as user_admin
-    visit bootstrap_live_table_path
+    live_table_props = {initialNumToRender: rows.length, maxToRenderPerBatch: rows.length}
+    visit bootstrap_live_table_path(live_table_props: JSON.generate(live_table_props))
     wait_for_expect { expect(all("[data-class='task-row']").length).to eq 30 }
 
     # Selecting "All" above the threshold (default 1000) warns instead of loading everything.


### PR DESCRIPTION
## Summary

- make the large per-page system spec render its known fixture in one FlatList batch
- preserve the warning, cancel, proceed, and exact 1001-row assertions
- document the FlatList batching lesson for future system specs

## Validation

- `git diff --check`
- Ruby 3.3.5 container: `ruby -c ruby-gem/spec/system/api_maker_table/per_page_spec.rb`

## Container system-spec blocker

The available Docker daemon cannot bind-mount this workspace; the documented Rails 6/7 Firefox workflow stopped at `cd: ruby-gem: No such file or directory` because `/workspace` was empty. Host Ruby/Bundler was intentionally not used.